### PR TITLE
feat: add agenda similarity check API

### DIFF
--- a/semanticnews/agenda/api.py
+++ b/semanticnews/agenda/api.py
@@ -1,0 +1,70 @@
+from datetime import date
+from typing import List
+
+from django.db.models import F, Value
+from ninja import NinjaAPI, Schema
+from openai import OpenAI
+from pgvector.django import CosineDistance
+
+from .models import Entry
+
+
+api = NinjaAPI(title="Agenda API")
+
+
+class EntryCheckRequest(Schema):
+    """Request body for agenda entry checks."""
+
+    title: str
+    date: date
+
+
+class SimilarEntryResponse(Schema):
+    """Similar entry data returned by the API."""
+
+    uuid: str
+    title: str
+    date: date
+    relevance: float
+    distance: float
+
+
+@api.post("/check-entry", response=List[SimilarEntryResponse])
+def check_entry(request, payload: EntryCheckRequest):
+    """Check whether an agenda entry already exists.
+
+    The endpoint creates an embedding based on the entry's title and date
+    (title + month + year) and compares it against existing agenda entries
+    using cosine similarity. Entries with a similarity greater than the
+    defined threshold are returned, ordered by relevance.
+    """
+
+    embedding_input = f"{payload.title} {payload.date:%B} {payload.date:%Y}"
+
+    with OpenAI() as client:
+        embedding = client.embeddings.create(
+            model="text-embedding-3-small",
+            input=embedding_input,
+        ).data[0].embedding
+
+    threshold = 0.8
+
+    queryset = (
+        Entry.objects.exclude(embedding__isnull=True)
+        .annotate(distance=CosineDistance("embedding", embedding))
+        .annotate(relevance=Value(1.0) - F("distance"))
+        .filter(relevance__gte=threshold)
+        .order_by("-relevance")
+    )
+
+    return [
+        SimilarEntryResponse(
+            uuid=str(entry.uuid),
+            title=entry.title,
+            date=entry.date,
+            relevance=entry.relevance,
+            distance=entry.distance,
+        )
+        for entry in queryset
+    ]
+

--- a/semanticnews/urls.py
+++ b/semanticnews/urls.py
@@ -7,6 +7,7 @@ from . import views as core_views
 from .profiles import views as profiles_views
 from .topics import views as topics_views
 from .agenda import views as agenda_views
+from .agenda.api import api as agenda_api
 
 
 urlpatterns = [
@@ -14,6 +15,7 @@ urlpatterns = [
     path('i18n/', include('django.conf.urls.i18n')),
     path("login/", LoginView.as_view(), name="login"),
     path('logout/', LogoutView.as_view(), name='logout'),
+    path('api/agenda/', agenda_api.urls),
 ]
 
 


### PR DESCRIPTION
## Summary
- add Ninja API for agenda entry similarity lookup
- expose `/api/agenda/check-entry` to find existing entries by embedding closeness

## Testing
- `python manage.py test semanticnews.agenda`


------
https://chatgpt.com/codex/tasks/task_b_68aaf14e248883289b8f4e3b2e7a7079