### PR TITLE
Add event modal with similar search and creation workflow

### DIFF
--- a/semanticnews/agenda/templates/agenda/event_list.html
+++ b/semanticnews/agenda/templates/agenda/event_list.html
@@ -9,6 +9,8 @@
 
 <div class="container">
 
+    <button id="addEventBtn" class="btn btn-primary mb-3">{% trans "Add event" %}</button>
+
     <div class="row h-100">
 
         <div class="col-12 col-md-8">
@@ -30,5 +32,39 @@
 
 </div>
 
+<div class="modal fade" id="addEventModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form id="addEventForm">
+                <div class="modal-header">
+                    <h5 class="modal-title">{% trans "Add event" %}</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label for="eventDate" class="form-label">{% trans "Date" %}</label>
+                        <input type="date" class="form-control" id="eventDate" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="eventTitle" class="form-label">{% trans "Title" %}</label>
+                        <input type="text" class="form-control" id="eventTitle" required>
+                    </div>
+                    <div id="similarEvents"></div>
+                </div>
+                <div class="modal-footer">
+                    <button type="submit" class="btn btn-primary">{% trans "Submit" %}</button>
+                    <button type="button" class="btn btn-success d-none" id="confirmCreateBtn">{% trans "Create event" %}</button>
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Close" %}</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+{% endblock %}
+
+{% block extra_js %}
+    {{ block.super }}
+    <script src="{% static 'agenda/event_modal.js' %}"></script>
 {% endblock %}
 

--- a/static/agenda/event_modal.js
+++ b/static/agenda/event_modal.js
@@ -1,0 +1,68 @@
+// Handles the add event modal workflow
+
+document.addEventListener('DOMContentLoaded', function () {
+  const modalElement = document.getElementById('addEventModal');
+  if (!modalElement) return;
+  const modal = new bootstrap.Modal(modalElement);
+  const form = document.getElementById('addEventForm');
+  const similarContainer = document.getElementById('similarEvents');
+  const createButton = document.getElementById('confirmCreateBtn');
+
+  document.getElementById('addEventBtn').addEventListener('click', () => {
+    form.reset();
+    similarContainer.innerHTML = '';
+    createButton.classList.add('d-none');
+    modal.show();
+  });
+
+  form.addEventListener('submit', async function (e) {
+    e.preventDefault();
+    const title = document.getElementById('eventTitle').value;
+    const date = document.getElementById('eventDate').value;
+
+    const res = await fetch('/api/agenda/get-similar', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, date })
+    });
+    const data = await res.json();
+
+    if (Array.isArray(data) && data.length) {
+      similarContainer.innerHTML = '<p>Similar events found. You can open one or create a new event.</p>';
+      const list = document.createElement('div');
+      list.className = 'list-group mb-3';
+      data.forEach(ev => {
+        const a = document.createElement('a');
+        a.className = 'list-group-item list-group-item-action';
+        a.href = ev.url;
+        a.textContent = `${ev.title} (${ev.date})`;
+        list.appendChild(a);
+      });
+      similarContainer.appendChild(list);
+      createButton.classList.remove('d-none');
+      createButton.onclick = () => validateAndCreate(title, date);
+    } else {
+      await validateAndCreate(title, date);
+    }
+  });
+
+  async function validateAndCreate(title, date) {
+    const valRes = await fetch('/api/agenda/validate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, date })
+    });
+    const valData = await valRes.json();
+    if (valData.confidence >= 0.5) {
+      const createRes = await fetch('/api/agenda/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title, date })
+      });
+      const created = await createRes.json();
+      window.location.href = created.url;
+    } else {
+      alert('Event could not be validated.');
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add API support for returning similar events with URLs
- introduce event validation and creation endpoints
- add frontend modal to create events after similarity check
- cover new API with tests

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68ab0986dca88328b6ba371792452b5c