### PR TITLE
feat: add event suggestions endpoint to agenda API

### DIFF
--- a/semanticnews/agenda/tests.py
+++ b/semanticnews/agenda/tests.py
@@ -39,6 +39,31 @@ class ValidateEventTests(SimpleTestCase):
         )
 
 
+class SuggestEventsTests(SimpleTestCase):
+    @patch("semanticnews.agenda.api.OpenAI")
+    def test_suggest_events_returns_events(self, mock_openai):
+        mock_client = MagicMock()
+        mock_openai.return_value.__enter__.return_value = mock_client
+        mock_response = MagicMock()
+        mock_content = MagicMock()
+        mock_events = [
+            {"title": "Event A", "date": "2024-06-01"},
+            {"title": "Event B", "date": "2024-06-15"},
+        ]
+        mock_content.json = mock_events
+        mock_response.output = [MagicMock(content=[mock_content])]
+        mock_client.responses.create.return_value = mock_response
+
+        response = self.client.get(
+            "/api/agenda/suggest",
+            {"year": 2024, "month": 6, "locality": "USA", "limit": 2},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), mock_events)
+        mock_client.responses.create.assert_called_once()
+
+
 class CreateEventTests(TestCase):
     def test_create_event_endpoint_creates_event(self):
         payload = {"title": "My Event", "date": "2024-01-02"}


### PR DESCRIPTION
## Summary
- add `/suggest` endpoint to Agenda API to fetch top significant events for a given time period and optional locality using OpenAI responses with web_search_preview
- cover suggestion endpoint with unit test

## Testing
- `python manage.py test semanticnews.agenda.tests.ValidateEventTests semanticnews.agenda.tests.SuggestEventsTests`

------
https://chatgpt.com/codex/tasks/task_b_68ab0ce5d0c88328b5a1f8b9af26bad9