### PR TITLE
Add admin suggestions view for agenda events

### DIFF
--- a/semanticnews/agenda/api.py
+++ b/semanticnews/agenda/api.py
@@ -156,6 +156,7 @@ def suggest_events(
     start_date: date | None = None,
     end_date: date | None = None,
     locality: str | None = None,
+    categories: str | None = None,
     limit: int = 10,
     exclude: List[AgendaEventResponse] | None = None,
 ):
@@ -163,6 +164,7 @@ def suggest_events(
 
     Args:
         exclude: Optional list of events to omit from the suggestions.
+        categories: Optional comma-separated list of categories to focus on.
     """
 
     if start_date and end_date:
@@ -181,6 +183,8 @@ def suggest_events(
 
     if locality:
         timeframe += f" in {locality}"
+    if categories:
+        timeframe += f" about {categories}"
 
     parsed_exclude: List[AgendaEventResponse] = []
     if exclude:

--- a/semanticnews/agenda/forms.py
+++ b/semanticnews/agenda/forms.py
@@ -1,0 +1,22 @@
+from datetime import date
+import calendar
+
+from django import forms
+
+from .models import Locality, Category
+
+
+class EventSuggestForm(forms.Form):
+    start_date = forms.DateField()
+    end_date = forms.DateField()
+    locality = forms.ModelChoiceField(queryset=Locality.objects.all(), required=False)
+    categories = forms.ModelMultipleChoiceField(queryset=Category.objects.all(), required=False)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not self.is_bound:
+            today = date.today()
+            first = date(today.year, today.month, 1)
+            last = date(today.year, today.month, calendar.monthrange(today.year, today.month)[1])
+            self.initial.setdefault('start_date', first)
+            self.initial.setdefault('end_date', last)

--- a/semanticnews/agenda/templates/admin/agenda/event/change_list.html
+++ b/semanticnews/agenda/templates/admin/agenda/event/change_list.html
@@ -1,0 +1,6 @@
+{% extends "admin/change_list.html" %}
+
+{% block object-tools-items %}
+<li><a href="{% url 'admin:agenda_event_suggest' %}" class="addlink">Suggest events</a></li>
+{{ block.super }}
+{% endblock %}

--- a/semanticnews/agenda/templates/admin/agenda/event/suggest.html
+++ b/semanticnews/agenda/templates/admin/agenda/event/suggest.html
@@ -1,0 +1,13 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block content %}
+<h1>{% trans "Suggest events" %}</h1>
+<form method="post" novalidate>
+    {% csrf_token %}
+    <table>
+        {{ form.as_table }}
+    </table>
+    <input type="submit" value="{% trans 'Fetch suggestions' %}" class="default" />
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add EventSuggestForm to capture date range, locality, and categories
- Extend EventAdmin with custom view using agenda/suggest endpoint to create events
- Support category filtering in suggest_events API and expose link in admin

## Testing
- ❌ `python manage.py test` *(failed: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*


------
https://chatgpt.com/codex/tasks/task_b_68ac156f476c8328a14785020fe8332f