### PR TITLE
Handle low-confidence event creations

### DIFF
--- a/semanticnews/agenda/api.py
+++ b/semanticnews/agenda/api.py
@@ -10,6 +10,9 @@ from pgvector.django import CosineDistance
 from .models import Event
 
 
+CONFIDENCE_THRESHOLD = 0.85
+
+
 api = NinjaAPI(title="Agenda API")
 
 
@@ -127,10 +130,17 @@ class EventCreateResponse(Schema):
 def create_event(request, payload: EventCreateRequest):
     """Create a new agenda event."""
 
+    status = (
+        "published"
+        if payload.confidence is not None and payload.confidence >= CONFIDENCE_THRESHOLD
+        else "draft"
+    )
+
     event = Event.objects.create(
         title=payload.title,
         date=payload.date,
         confidence=payload.confidence,
+        status=status,
         created_by=request.user if getattr(request, "user", None) and request.user.is_authenticated else None,
     )
 

--- a/semanticnews/agenda/tests.py
+++ b/semanticnews/agenda/tests.py
@@ -126,3 +126,17 @@ class CreateEventTests(TestCase):
         event = Event.objects.first()
         self.assertEqual(data["url"], event.get_absolute_url())
         self.assertEqual(event.confidence, 0.85)
+        self.assertEqual(event.status, "published")
+
+    def test_low_confidence_creates_draft_event(self):
+        payload = {"title": "Low Confidence", "date": "2024-01-03", "confidence": 0.5}
+        response = self.client.post(
+            "/api/agenda/create", payload, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 200)
+
+        from .models import Event
+
+        self.assertEqual(Event.objects.count(), 1)
+        event = Event.objects.first()
+        self.assertEqual(event.status, "draft")

--- a/static/agenda/event_modal.js
+++ b/static/agenda/event_modal.js
@@ -55,16 +55,15 @@ document.addEventListener('DOMContentLoaded', function () {
       body: JSON.stringify({ title, date })
     });
     const valData = await valRes.json();
-    if (valData.confidence >= CONFIDENCE_THRESHOLD) {
-      const createRes = await fetch('/api/agenda/create', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title, date, confidence: valData.confidence })
-      });
-      const created = await createRes.json();
-      window.location.href = created.url;
-    } else {
-      alert('Event could not be validated.');
+    const createRes = await fetch('/api/agenda/create', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, date, confidence: valData.confidence })
+    });
+    const created = await createRes.json();
+    if (valData.confidence < CONFIDENCE_THRESHOLD) {
+      alert('Event created as draft due to low confidence.');
     }
+    window.location.href = created.url;
   }
 });


### PR DESCRIPTION
## Summary
- Publish agenda events when the validation confidence meets a configurable threshold
- Save low-confidence user events as drafts instead of preventing creation
- Add tests for draft and published event outcomes

## Testing
- `python manage.py test` *(fails: connection to PostgreSQL at "localhost" refused)*

------
https://chatgpt.com/codex/tasks/task_b_68ac450cad6083288a42cb8b35bbdd86