### PR TITLE
Show recent agenda events on homepage

### DIFF
--- a/semanticnews/agenda/templates/agenda/event_list_item.html
+++ b/semanticnews/agenda/templates/agenda/event_list_item.html
@@ -1,3 +1,6 @@
 
-<h2 class="fs-4">{{ event.title }}</h2>
+<div class="mb-3">
+    <p class="text-muted small mb-0">{{ event.date|date:"M d, Y" }}</p>
+    <h2 class="fs-5"><a href="{{ event.get_absolute_url }}">{{ event.title }}</a></h2>
+</div>
 

--- a/semanticnews/templates/home.html
+++ b/semanticnews/templates/home.html
@@ -20,9 +20,11 @@
         </div>
 
         <div class="col-12 col-md-4">
-
-            {% include "agenda/event_list_item.html" %}
-
+            {% for event in events %}
+                {% include "agenda/event_list_item.html" %}
+            {% empty %}
+                <p>{% trans "No upcoming events" %}</p>
+            {% endfor %}
         </div>
 
     </div>

--- a/semanticnews/views.py
+++ b/semanticnews/views.py
@@ -4,8 +4,9 @@ from .topics.models import Topic
 
 
 def home(request):
+    recent_events = Event.objects.filter(status='published').order_by('-date')[:5]
     return render(request, 'home.html', {
-        'events': Event.objects.all(),
+        'events': recent_events,
         'topics': Topic.objects.all(),
     })
 


### PR DESCRIPTION
## Summary
- Display up to five published agenda events on the home page sidebar, ordered by most recent.
- Replace single-event placeholder with loop over event snippets and graceful empty state.
- Enhance event list item template with date and link to event detail.

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ac77b29338832895dc6b4e07a20a9c