### PR TITLE
Add related event suggestion modal

### DIFF
--- a/semanticnews/agenda/templates/agenda/event_detail.html
+++ b/semanticnews/agenda/templates/agenda/event_detail.html
@@ -22,7 +22,10 @@
 
         <div class="col-12 col-md-4">
 
-            <h2 class="fs-5">{% trans "Related events" %}</h2>
+            <div class="d-flex justify-content-between align-items-center mb-2">
+                <h2 class="fs-5 mb-0">{% trans "Related events" %}</h2>
+                <button id="suggestEventsBtn" data-event-title="{{ event.title }}" class="btn btn-sm btn-outline-secondary" title="{% trans 'Add events' %}">[+]</button>
+            </div>
 
             {% for sim_event in similar_events %}
                 {% include "agenda/event_list_item.html" with event=sim_event %}
@@ -34,4 +37,27 @@
     </div>
 </div>
 
+<div class="modal fade" id="suggestEventsModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">{% trans "Add related events" %}</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans 'Close' %}"></button>
+            </div>
+            <div class="modal-body" id="suggestedEventsList">
+                <p>{% trans "Loading suggestions..." %}</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-primary" id="createSelectedEventsBtn">{% trans "Create selected" %}</button>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Close" %}</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+{% endblock %}
+
+{% block extra_js %}
+    {{ block.super }}
+    <script src="{% static 'agenda/event_suggestions.js' %}"></script>
 {% endblock %}

--- a/static/agenda/event_suggestions.js
+++ b/static/agenda/event_suggestions.js
@@ -1,0 +1,61 @@
+// Handles fetching and creating suggested related events
+
+document.addEventListener('DOMContentLoaded', function () {
+  const btn = document.getElementById('suggestEventsBtn');
+  const modalEl = document.getElementById('suggestEventsModal');
+  if (!btn || !modalEl) return;
+
+  const modal = new bootstrap.Modal(modalEl);
+  const list = document.getElementById('suggestedEventsList');
+  const createBtn = document.getElementById('createSelectedEventsBtn');
+
+  btn.addEventListener('click', async () => {
+    list.innerHTML = '<p>Loading suggestions...</p>';
+    createBtn.disabled = true;
+    modal.show();
+    try {
+      const title = btn.dataset.eventTitle;
+      const res = await fetch(`/api/agenda/suggest?related_event=${encodeURIComponent(title)}`);
+      const data = await res.json();
+      if (Array.isArray(data) && data.length) {
+        list.innerHTML = '';
+        data.forEach((ev, idx) => {
+          const wrapper = document.createElement('div');
+          wrapper.className = 'form-check';
+          const cb = document.createElement('input');
+          cb.type = 'checkbox';
+          cb.className = 'form-check-input';
+          cb.id = `suggest${idx}`;
+          cb.value = JSON.stringify(ev);
+          const label = document.createElement('label');
+          label.className = 'form-check-label';
+          label.htmlFor = cb.id;
+          const cats = ev.categories && ev.categories.length ? ` - ${ev.categories.join(', ')}` : '';
+          label.textContent = `${ev.title} (${ev.date})${cats}`;
+          wrapper.appendChild(cb);
+          wrapper.appendChild(label);
+          list.appendChild(wrapper);
+        });
+        createBtn.disabled = false;
+      } else {
+        list.innerHTML = '<p>No suggestions found.</p>';
+      }
+    } catch (err) {
+      list.innerHTML = '<p>Error loading suggestions.</p>';
+    }
+  });
+
+  createBtn.addEventListener('click', async () => {
+    const checked = list.querySelectorAll('input[type="checkbox"]:checked');
+    for (const cb of checked) {
+      const ev = JSON.parse(cb.value);
+      await fetch('/api/agenda/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: ev.title, date: ev.date })
+      });
+    }
+    modal.hide();
+    window.location.reload();
+  });
+});


### PR DESCRIPTION
## Summary
- add [+] button to event detail page that fetches suggestions from agenda/suggest
- allow selecting suggested events in a modal and create them via API

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68acafa3619483289bda5b638603986d