### PR TITLE
Show related topics on event page

### DIFF
--- a/semanticnews/agenda/templates/agenda/event_detail.html
+++ b/semanticnews/agenda/templates/agenda/event_detail.html
@@ -18,6 +18,14 @@
 
     <div class="row">
         <div class="col-12 col-md-8">
+            <h2 class="fs-5">{% trans "Topics" %}</h2>
+            <ul class="list-unstyled">
+                {% for topic in event.topics.all %}
+                    <li><a href="{{ topic.get_absolute_url }}">{{ topic.title }}</a></li>
+                {% empty %}
+                    <li class="text-muted">{% trans "No topics" %}</li>
+                {% endfor %}
+            </ul>
         </div>
 
         <div class="col-12 col-md-4">

--- a/semanticnews/agenda/tests.py
+++ b/semanticnews/agenda/tests.py
@@ -209,3 +209,24 @@ class SuggestViewAdminTests(TestCase):
             set(event.categories.values_list("name", flat=True)),
             {"Politics", "Economy"},
         )
+
+
+class EventDetailTopicTests(TestCase):
+    def test_event_detail_shows_topics(self):
+        from datetime import date
+        from semanticnews.topics.models import Topic, TopicEvent
+
+        event = Event.objects.create(
+            title="My Event",
+            date=date(2024, 1, 1),
+            embedding=[0.0] * 1536,
+        )
+        topic1 = Topic.objects.create(title="Topic One", embedding=[0.0] * 1536)
+        topic2 = Topic.objects.create(title="Topic Two", embedding=[0.0] * 1536)
+        TopicEvent.objects.create(topic=topic1, event=event)
+        TopicEvent.objects.create(topic=topic2, event=event)
+
+        response = self.client.get(event.get_absolute_url())
+
+        self.assertContains(response, "Topic One")
+        self.assertContains(response, "Topic Two")

--- a/semanticnews/agenda/views.py
+++ b/semanticnews/agenda/views.py
@@ -10,7 +10,11 @@ from .models import Event
 
 def event_detail(request, year, month, day, slug):
     obj = get_object_or_404(
-        Event, slug=slug, date__year=year, date__month=month, date__day=day
+        Event.objects.prefetch_related("topics"),
+        slug=slug,
+        date__year=year,
+        date__month=month,
+        date__day=day,
     )
 
     if obj.embedding is not None:


### PR DESCRIPTION
## Summary
- list topics associated with an event on the event detail page
- prefetch event topics in view
- cover topic listing in tests

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68acbb90d3408328aad4d30de11c319a