### PR TITLE
Add locality and date filters to event suggestion modal

### DIFF
--- a/semanticnews/agenda/templates/agenda/event_detail.html
+++ b/semanticnews/agenda/templates/agenda/event_detail.html
@@ -54,8 +54,25 @@
                 <h5 class="modal-title">{% trans "Add related events" %}</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans 'Close' %}"></button>
             </div>
-            <div class="modal-body" id="suggestedEventsList">
-                <p>{% trans "Loading suggestions..." %}</p>
+            <div class="modal-body">
+                <form id="suggestEventsForm" class="mb-3">
+                    <div class="mb-3">
+                        <label for="suggestLocality" class="form-label">{% trans "Locality" %}</label>
+                        <input type="text" class="form-control" id="suggestLocality">
+                    </div>
+                    <div class="mb-3">
+                        <label for="suggestStartDate" class="form-label">{% trans "Start date" %}</label>
+                        <input type="date" class="form-control" id="suggestStartDate">
+                    </div>
+                    <div class="mb-3">
+                        <label for="suggestEndDate" class="form-label">{% trans "End date" %}</label>
+                        <input type="date" class="form-control" id="suggestEndDate">
+                    </div>
+                    <button type="submit" class="btn btn-primary">{% trans "Fetch suggestions" %}</button>
+                </form>
+                <div id="suggestedEventsList" class="d-none">
+                    <p>{% trans "Loading suggestions..." %}</p>
+                </div>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-primary" id="createSelectedEventsBtn">{% trans "Create selected" %}</button>

--- a/static/agenda/event_suggestions.js
+++ b/static/agenda/event_suggestions.js
@@ -6,16 +6,35 @@ document.addEventListener('DOMContentLoaded', function () {
   if (!btn || !modalEl) return;
 
   const modal = new bootstrap.Modal(modalEl);
+  const form = document.getElementById('suggestEventsForm');
   const list = document.getElementById('suggestedEventsList');
   const createBtn = document.getElementById('createSelectedEventsBtn');
 
-  btn.addEventListener('click', async () => {
-    list.innerHTML = '<p>Loading suggestions...</p>';
+  btn.addEventListener('click', () => {
+    form.reset();
+    form.classList.remove('d-none');
+    list.innerHTML = '';
+    list.classList.add('d-none');
     createBtn.disabled = true;
     modal.show();
+  });
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    list.innerHTML = '<p>Loading suggestions...</p>';
+    list.classList.remove('d-none');
+    createBtn.disabled = true;
     try {
       const title = btn.dataset.eventTitle;
-      const res = await fetch(`/api/agenda/suggest?related_event=${encodeURIComponent(title)}`);
+      const params = new URLSearchParams();
+      if (title) params.append('related_event', title);
+      const locality = document.getElementById('suggestLocality').value;
+      const startDate = document.getElementById('suggestStartDate').value;
+      const endDate = document.getElementById('suggestEndDate').value;
+      if (locality) params.append('locality', locality);
+      if (startDate) params.append('start_date', startDate);
+      if (endDate) params.append('end_date', endDate);
+      const res = await fetch(`/api/agenda/suggest?${params.toString()}`);
       const data = await res.json();
       if (Array.isArray(data) && data.length) {
         list.innerHTML = '';
@@ -43,6 +62,7 @@ document.addEventListener('DOMContentLoaded', function () {
     } catch (err) {
       list.innerHTML = '<p>Error loading suggestions.</p>';
     }
+    form.classList.add('d-none');
   });
 
   createBtn.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- show form for locality and date range before fetching related event suggestions
- fetch suggestions using selected criteria

## Testing
- `pytest` (no tests found)
- `python manage.py test` (fails: connection to server at 'localhost' (127.0.0.1), port 5432 refused)


------
https://chatgpt.com/codex/tasks/task_b_68ad35cdd48083289ed5a84d12b9775d