### PR TITLE
feat: add locality select with global option

### DIFF
--- a/semanticnews/agenda/forms.py
+++ b/semanticnews/agenda/forms.py
@@ -9,7 +9,11 @@ from .models import Locality, Category
 class EventSuggestForm(forms.Form):
     start_date = forms.DateField()
     end_date = forms.DateField()
-    locality = forms.ModelChoiceField(queryset=Locality.objects.all(), required=False)
+    locality = forms.ModelChoiceField(
+        queryset=Locality.objects.all().order_by("-is_default", "name"),
+        required=False,
+        empty_label="Global",
+    )
     categories = forms.ModelMultipleChoiceField(queryset=Category.objects.all(), required=False)
 
     def __init__(self, *args, **kwargs):

--- a/semanticnews/agenda/templates/agenda/event_detail.html
+++ b/semanticnews/agenda/templates/agenda/event_detail.html
@@ -58,7 +58,12 @@
                 <form id="suggestEventsForm" class="mb-3">
                     <div class="mb-3">
                         <label for="suggestLocality" class="form-label">{% trans "Locality" %}</label>
-                        <input type="text" class="form-control" id="suggestLocality">
+                        <select class="form-select" id="suggestLocality">
+                            <option value="">{% trans "Global" %}</option>
+                            {% for locality in localities %}
+                                <option value="{{ locality.name }}">{{ locality.name }}</option>
+                            {% endfor %}
+                        </select>
                     </div>
                     <div class="mb-3">
                         <label for="suggestStartDate" class="form-label">{% trans "Start date" %}</label>

--- a/semanticnews/agenda/tests.py
+++ b/semanticnews/agenda/tests.py
@@ -230,3 +230,23 @@ class EventDetailTopicTests(TestCase):
 
         self.assertContains(response, "Topic One")
         self.assertContains(response, "Topic Two")
+
+
+class EventDetailLocalityTests(TestCase):
+    def test_locality_select_lists_localities(self):
+        from datetime import date
+        from .models import Locality, Event
+
+        event = Event.objects.create(
+            title="My Event",
+            date=date(2024, 1, 1),
+            embedding=[0.0] * 1536,
+        )
+        default_loc = Locality.objects.create(name="USA", is_default=True)
+        other_loc = Locality.objects.create(name="France")
+
+        response = self.client.get(event.get_absolute_url())
+
+        self.assertContains(response, '<option value="">Global</option>', html=True)
+        content = response.content.decode()
+        self.assertLess(content.index(default_loc.name), content.index(other_loc.name))

--- a/semanticnews/agenda/views.py
+++ b/semanticnews/agenda/views.py
@@ -5,7 +5,7 @@ from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.shortcuts import get_object_or_404, render
 from pgvector.django import L2Distance
 
-from .models import Event
+from .models import Event, Locality
 
 
 def event_detail(request, year, month, day, slug):
@@ -31,6 +31,8 @@ def event_detail(request, year, month, day, slug):
         similar_events = Event.objects.none()
         exclude_events = []
 
+    localities = Locality.objects.all().order_by("-is_default", "name")
+
     return render(
         request,
         "agenda/event_detail.html",
@@ -38,6 +40,7 @@ def event_detail(request, year, month, day, slug):
             "event": obj,
             "similar_events": similar_events,
             "exclude_events": exclude_events,
+            "localities": localities,
         },
     )
 


### PR DESCRIPTION
## Summary
- show localities with default ones first in suggestion form
- support selecting a global locality option
- test locality select ordering and default

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68ad3c0c0ab88328b92cedbd4173aee7