### PR TITLE
feat: log OpenAI payloads in debug

### DIFF
--- a/semanticnews/agenda/api.py
+++ b/semanticnews/agenda/api.py
@@ -4,7 +4,7 @@ import json
 
 from django.db.models import F, Value
 from ninja import NinjaAPI, Schema
-from openai import OpenAI
+from semanticnews.openai import OpenAI
 from pgvector.django import CosineDistance
 
 from .models import Event

--- a/semanticnews/agenda/models.py
+++ b/semanticnews/agenda/models.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.urls import reverse
 from django.conf import settings
-from openai import OpenAI
+from semanticnews.openai import OpenAI
 from pgvector.django import VectorField, HnswIndex
 from slugify import slugify
 

--- a/semanticnews/contents/models.py
+++ b/semanticnews/contents/models.py
@@ -1,6 +1,6 @@
 import uuid
 
-from openai import OpenAI, AsyncOpenAI
+from semanticnews.openai import OpenAI, AsyncOpenAI
 from pgvector.django import VectorField, L2Distance, HnswIndex
 from django.db import models
 from django.core.validators import URLValidator, MinValueValidator, MaxValueValidator

--- a/semanticnews/contents/sources/documents/models.py
+++ b/semanticnews/contents/sources/documents/models.py
@@ -1,4 +1,4 @@
-from openai import AsyncOpenAI, OpenAI
+from semanticnews.openai import AsyncOpenAI, OpenAI
 from django.db import models
 
 

--- a/semanticnews/contents/sources/rss/models.py
+++ b/semanticnews/contents/sources/rss/models.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 import requests
 import feedparser
-from openai import OpenAI, AsyncOpenAI
+from semanticnews.openai import OpenAI, AsyncOpenAI
 
 from django.utils.html import strip_tags
 from django.db import models

--- a/semanticnews/contents/sources/youtube/models.py
+++ b/semanticnews/contents/sources/youtube/models.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from googleapiclient.discovery import build
 from pgvector.django import VectorField
 from youtube_transcript_api import YouTubeTranscriptApi, NoTranscriptFound, TranscriptsDisabled
-from openai import OpenAI
+from semanticnews.openai import OpenAI
 
 from ..youtube.utils import list_youtube_transcripts
 

--- a/semanticnews/openai.py
+++ b/semanticnews/openai.py
@@ -1,0 +1,68 @@
+import logging
+from django.conf import settings
+import httpx
+from openai import OpenAI as _OpenAI, AsyncOpenAI as _AsyncOpenAI
+
+logger = logging.getLogger(__name__)
+
+
+def _get_http_client():
+    if not getattr(settings, "DEBUG", False):
+        return None
+
+    def log_request(request: httpx.Request):
+        try:
+            body = request.content.decode()
+        except Exception:
+            body = str(request.content)
+        logger.debug("OpenAI request %s %s: %s", request.method, request.url, body)
+
+    def log_response(response: httpx.Response):
+        body = response.read().decode()
+        logger.debug(
+            "OpenAI response %s %s: %s", response.status_code, response.url, body
+        )
+
+    return httpx.Client(event_hooks={"request": [log_request], "response": [log_response]})
+
+
+def _get_async_http_client():
+    if not getattr(settings, "DEBUG", False):
+        return None
+
+    async def log_request(request: httpx.Request):
+        try:
+            body = request.content.decode()
+        except Exception:
+            body = str(request.content)
+        logger.debug("OpenAI request %s %s: %s", request.method, request.url, body)
+
+    async def log_response(response: httpx.Response):
+        body = (await response.aread()).decode()
+        logger.debug(
+            "OpenAI response %s %s: %s", response.status_code, response.url, body
+        )
+
+    return httpx.AsyncClient(event_hooks={"request": [log_request], "response": [log_response]})
+
+
+class OpenAI(_OpenAI):
+    """OpenAI client that logs requests and responses when DEBUG is True."""
+
+    def __init__(self, *args, **kwargs):
+        if "http_client" not in kwargs:
+            client = _get_http_client()
+            if client is not None:
+                kwargs["http_client"] = client
+        super().__init__(*args, **kwargs)
+
+
+class AsyncOpenAI(_AsyncOpenAI):
+    """AsyncOpenAI client that logs requests and responses when DEBUG is True."""
+
+    def __init__(self, *args, **kwargs):
+        if "http_client" not in kwargs:
+            client = _get_async_http_client()
+            if client is not None:
+                kwargs["http_client"] = client
+        super().__init__(*args, **kwargs)

--- a/semanticnews/topics/models.py
+++ b/semanticnews/topics/models.py
@@ -8,7 +8,7 @@ from django.contrib.auth import get_user_model
 from django.utils.translation import gettext_lazy as _, get_language
 from django.conf import settings
 from slugify import slugify
-from openai import OpenAI, AsyncOpenAI
+from semanticnews.openai import OpenAI, AsyncOpenAI
 from pgvector.django import VectorField, L2Distance, HnswIndex
 from ..utils import translate, get_relevance
 

--- a/semanticnews/topics/utils/images/tasks.py
+++ b/semanticnews/topics/utils/images/tasks.py
@@ -2,7 +2,7 @@ import base64
 from io import BytesIO
 from PIL import Image
 from django.core.files.base import ContentFile
-from openai import OpenAI
+from semanticnews.openai import OpenAI
 
 from .models import TopicImage
 

--- a/semanticnews/users/models.py
+++ b/semanticnews/users/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from openai import OpenAI
+from semanticnews.openai import OpenAI
 from pgvector.django import VectorField, HnswIndex
 from django.contrib.auth.models import AbstractUser
 

--- a/semanticnews/utils.py
+++ b/semanticnews/utils.py
@@ -1,6 +1,6 @@
 import json
 import numpy as np
-from openai import OpenAI
+from semanticnews.openai import OpenAI
 from functools import wraps
 from django.views.decorators.cache import cache_page
 from django.utils.translation import get_language


### PR DESCRIPTION
## Summary
- add wrapper clients that log OpenAI requests and responses when `DEBUG` is true
- route OpenAI usage through the new logging client

## Testing
- `python -m pytest`
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68ad48703a4083289609d98a944ccb42