### PR TITLE
Show related event title when suggesting events

### DIFF
--- a/semanticnews/agenda/templates/agenda/event_detail.html
+++ b/semanticnews/agenda/templates/agenda/event_detail.html
@@ -57,6 +57,10 @@
             <div class="modal-body">
                 <form id="suggestEventsForm" class="mb-3">
                     <div class="mb-3">
+                        <label for="suggestRelatedEvent" class="form-label">{% trans "Related event" %}</label>
+                        <input type="text" class="form-control" id="suggestRelatedEvent" value="{{ event.title }}" readonly>
+                    </div>
+                    <div class="mb-3">
                         <label for="suggestLocality" class="form-label">{% trans "Locality" %}</label>
                         <select class="form-select" id="suggestLocality">
                             <option value="">{% trans "Global" %}</option>

--- a/static/agenda/event_suggestions.js
+++ b/static/agenda/event_suggestions.js
@@ -9,6 +9,8 @@ document.addEventListener('DOMContentLoaded', function () {
   const form = document.getElementById('suggestEventsForm');
   const list = document.getElementById('suggestedEventsList');
   const createBtn = document.getElementById('createSelectedEventsBtn');
+  const fetchBtn = form.querySelector('button[type="submit"]');
+  const titleField = document.getElementById('suggestRelatedEvent');
   const existingEventsEl = document.getElementById('exclude-events');
   const existingEvents = existingEventsEl ? JSON.parse(existingEventsEl.textContent) : [];
 
@@ -18,6 +20,7 @@ document.addEventListener('DOMContentLoaded', function () {
     list.innerHTML = '';
     list.classList.add('d-none');
     createBtn.disabled = true;
+    if (fetchBtn) fetchBtn.disabled = false;
     modal.show();
   });
 
@@ -26,8 +29,9 @@ document.addEventListener('DOMContentLoaded', function () {
     list.innerHTML = '<p>Loading suggestions...</p>';
     list.classList.remove('d-none');
     createBtn.disabled = true;
+    if (fetchBtn) fetchBtn.disabled = true;
     try {
-      const title = btn.dataset.eventTitle;
+      const title = titleField ? titleField.value : btn.dataset.eventTitle;
       const params = new URLSearchParams();
       if (title) params.append('related_event', title);
       const locality = document.getElementById('suggestLocality').value;
@@ -70,6 +74,8 @@ document.addEventListener('DOMContentLoaded', function () {
       }
     } catch (err) {
       list.innerHTML = '<p>Error loading suggestions.</p>';
+    } finally {
+      if (fetchBtn) fetchBtn.disabled = false;
     }
   });
 


### PR DESCRIPTION
## Summary
- Show the related event title in the get-suggestions modal
- Disable the Fetch suggestions button until the API request completes

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68ad71ccf23483288d90e247f1d224bd