### PR TITLE
Create suggested events as drafts and allow publishing

### DIFF
--- a/semanticnews/agenda/templates/agenda/event_detail.html
+++ b/semanticnews/agenda/templates/agenda/event_detail.html
@@ -88,7 +88,7 @@
                 </div>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-primary" id="createSelectedEventsBtn">{% trans "Create selected" %}</button>
+                <button type="button" class="btn btn-primary" id="publishSelectedEventsBtn">{% trans "Publish selected" %}</button>
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Close" %}</button>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Automatically create suggested events as draft entries with categories and sources
- Add API endpoint to publish selected draft events
- Update suggestion modal to auto-draft events and offer "Publish selected" option

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: fe_sendauth: no password supplied)*

------
https://chatgpt.com/codex/tasks/task_b_68aead087ab08328a1df67dd3f2124e8