### PR TITLE
Add Topics API with create endpoint

### DIFF
--- a/semanticnews/topics/api.py
+++ b/semanticnews/topics/api.py
@@ -1,0 +1,51 @@
+from ninja import NinjaAPI, Schema
+from ninja.errors import HttpError
+from typing import Optional
+from .models import Topic
+
+api = NinjaAPI(title="Topics API")
+
+
+class TopicCreateRequest(Schema):
+    """Request body for creating a topic.
+
+    Attributes:
+        title (str): Title of the topic.
+    """
+
+    title: str
+
+
+class TopicCreateResponse(Schema):
+    """Response returned after creating a topic.
+
+    Attributes:
+        uuid (str): Unique identifier of the topic.
+        title (str): Title of the topic.
+        slug (str): Slug for the topic.
+    """
+
+    uuid: str
+    title: str
+    slug: str
+
+
+@api.post("/create", response=TopicCreateResponse)
+def create_topic(request, payload: TopicCreateRequest):
+    """Create a new topic for the authenticated user.
+
+    Args:
+        request: The HTTP request instance.
+        payload: Data including the topic title.
+
+    Returns:
+        Data for the newly created topic.
+    """
+
+    user = getattr(request, "user", None)
+    if not user or not user.is_authenticated:
+        raise HttpError(401, "Unauthorized")
+
+    topic = Topic.objects.create(title=payload.title, created_by=user)
+
+    return TopicCreateResponse(uuid=str(topic.uuid), title=topic.title, slug=topic.slug)

--- a/semanticnews/topics/tests.py
+++ b/semanticnews/topics/tests.py
@@ -1,3 +1,42 @@
-from django.test import TestCase
+from unittest.mock import patch
 
-# Create your tests here.
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+
+from .models import Topic
+
+
+class CreateTopicAPITests(TestCase):
+    """Tests for the topic creation API endpoint."""
+
+    def test_requires_authentication(self):
+        """Unauthenticated requests should be rejected."""
+
+        payload = {"title": "No Auth"}
+        response = self.client.post(
+            "/api/topics/create", payload, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 401)
+
+    @patch("semanticnews.topics.models.Topic.get_embedding", return_value=[0.0] * 1536)
+    def test_creates_topic_for_user(self, mock_get_embedding):
+        """Authenticated users can create topics."""
+
+        User = get_user_model()
+        user = User.objects.create_user("user", "user@example.com", "password")
+        self.client.force_login(user)
+
+        payload = {"title": "My Topic"}
+        response = self.client.post(
+            "/api/topics/create", payload, content_type="application/json"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["title"], "My Topic")
+
+        self.assertEqual(Topic.objects.count(), 1)
+        topic = Topic.objects.first()
+        self.assertEqual(topic.created_by, user)
+        self.assertEqual(str(topic.uuid), data["uuid"])
+

--- a/semanticnews/urls.py
+++ b/semanticnews/urls.py
@@ -6,6 +6,7 @@ from django.contrib.auth.views import LoginView, LogoutView
 from . import views as core_views
 from .profiles import views as profiles_views
 from .topics import views as topics_views
+from .topics.api import api as topics_api
 from .agenda import views as agenda_views
 from .agenda.api import api as agenda_api
 
@@ -16,6 +17,7 @@ urlpatterns = [
     path("login/", LoginView.as_view(), name="login"),
     path('logout/', LogoutView.as_view(), name='logout'),
     path('api/agenda/', agenda_api.urls),
+    path('api/topics/', topics_api.urls),
 ]
 
 


### PR DESCRIPTION
## Summary
- add Ninja API to manage topics and create topics for authenticated users
- expose topics API via `/api/topics/`
- add tests covering authentication and topic creation

## Testing
- `python manage.py test semanticnews/topics -v 2` *(fails: connection to server at "localhost", port 5432 failed: fe_sendauth: no password supplied)*

------
https://chatgpt.com/codex/tasks/task_b_68af0d9d97e0832895f1b51ed28802ee