### PR TITLE
Add endpoint to relate events to topics

### DIFF
--- a/semanticnews/topics/api.py
+++ b/semanticnews/topics/api.py
@@ -1,7 +1,10 @@
 from ninja import NinjaAPI, Schema
 from ninja.errors import HttpError
 from typing import Optional
-from .models import Topic
+
+from semanticnews.agenda.models import Event
+
+from .models import Topic, TopicEvent
 
 api = NinjaAPI(title="Topics API")
 
@@ -49,3 +52,73 @@ def create_topic(request, payload: TopicCreateRequest):
     topic = Topic.objects.create(title=payload.title, created_by=user)
 
     return TopicCreateResponse(uuid=str(topic.uuid), title=topic.title, slug=topic.slug)
+
+
+class TopicEventAddRequest(Schema):
+    """Request body for adding an agenda event to a topic.
+
+    Attributes:
+        topic_uuid (str): UUID of the topic.
+        event_uuid (str): UUID of the agenda event.
+        role (str): Role of the event within the topic (support, counter, context).
+    """
+
+    topic_uuid: str
+    event_uuid: str
+    role: Optional[str] = "support"
+
+
+class TopicEventAddResponse(Schema):
+    """Response returned after adding an event to a topic.
+
+    Attributes:
+        topic_uuid (str): UUID of the topic.
+        event_uuid (str): UUID of the agenda event.
+        role (str): Role assigned to the event within the topic.
+    """
+
+    topic_uuid: str
+    event_uuid: str
+    role: str
+
+
+@api.post("/add-event", response=TopicEventAddResponse)
+def add_event_to_topic(request, payload: TopicEventAddRequest):
+    """Add an agenda event to a topic for the authenticated user.
+
+    Args:
+        request: The HTTP request instance.
+        payload: Data including topic/event UUIDs and optional role.
+
+    Returns:
+        Data for the created relation between topic and event.
+    """
+
+    user = getattr(request, "user", None)
+    if not user or not user.is_authenticated:
+        raise HttpError(401, "Unauthorized")
+
+    try:
+        topic = Topic.objects.get(uuid=payload.topic_uuid)
+    except Topic.DoesNotExist:
+        raise HttpError(404, "Topic not found")
+
+    try:
+        event = Event.objects.get(uuid=payload.event_uuid)
+    except Event.DoesNotExist:
+        raise HttpError(404, "Event not found")
+
+    topic_event, created = TopicEvent.objects.get_or_create(
+        topic=topic,
+        event=event,
+        defaults={"role": payload.role, "created_by": user},
+    )
+
+    if not created:
+        raise HttpError(400, "Event already linked to topic")
+
+    return TopicEventAddResponse(
+        topic_uuid=str(topic.uuid),
+        event_uuid=str(event.uuid),
+        role=topic_event.role,
+    )


### PR DESCRIPTION
## Summary
- add API endpoint to attach agenda events to topics via M2M through model
- extend tests verifying authentication and successful linking

## Testing
- `python manage.py test` *(fails: connection to PostgreSQL at localhost:5432 refused)*

------
https://chatgpt.com/codex/tasks/task_b_68af1f94306883288c09e1f0a953c7e0