### PR TITLE
feat: add topic creation modal

### DIFF
--- a/semanticnews/templates/home.html
+++ b/semanticnews/templates/home.html
@@ -13,7 +13,7 @@
 
             <div class="d-flex justify-content-between align-items-center mb-2">
                 <h2 class="fs-5 mb-0">{%  trans "Topics" %}</h2>
-                <button id="addTopicBtn" class="btn btn-sm btn-outline-secondary" title="{% trans 'Add event' %}">
+                <button id="addTopicBtn" class="btn btn-sm btn-outline-secondary" title="{% trans 'Add topic' %}">
                     <i class="bi bi-plus-lg"></i>
                 </button>
             </div>
@@ -43,6 +43,8 @@
     </div>
 
 </div>
+
+{% include "topics/create_topic_modal.html" %}
 
 <div class="modal fade" id="addEventModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog">
@@ -78,4 +80,5 @@
 {% block extra_js %}
     {{ block.super }}
     <script src="{% static 'agenda/event_modal.js' %}"></script>
+    {% include "topics/create_topic_js.html" %}
 {% endblock %}

--- a/semanticnews/templates/topics/create_topic_js.html
+++ b/semanticnews/templates/topics/create_topic_js.html
@@ -1,0 +1,5 @@
+{% load static %}
+<script>
+  const CURRENT_USERNAME = "{{ request.user.username|escapejs }}";
+</script>
+<script src="{% static 'topics/create_topic_modal.js' %}"></script>

--- a/semanticnews/templates/topics/create_topic_modal.html
+++ b/semanticnews/templates/topics/create_topic_modal.html
@@ -1,0 +1,23 @@
+{% load i18n %}
+<div class="modal fade" id="createTopicModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form id="createTopicForm">
+                <div class="modal-header">
+                    <h5 class="modal-title">{% trans "Create new topic" %}</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label for="topicTitle" class="form-label">{% trans "Title" %}</label>
+                        <input type="text" class="form-control" id="topicTitle" required>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="submit" class="btn btn-primary">{% trans "Create topic" %}</button>
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Close" %}</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/static/topics/create_topic_modal.js
+++ b/static/topics/create_topic_modal.js
@@ -1,0 +1,38 @@
+// Handles the create topic modal workflow
+
+document.addEventListener('DOMContentLoaded', function () {
+  const modalElement = document.getElementById('createTopicModal');
+  if (!modalElement) return;
+  const modal = new bootstrap.Modal(modalElement);
+  const form = document.getElementById('createTopicForm');
+  const btn = document.getElementById('addTopicBtn');
+
+  if (btn) {
+    btn.addEventListener('click', () => {
+      form.reset();
+      modal.show();
+    });
+  }
+
+  form.addEventListener('submit', async function (e) {
+    e.preventDefault();
+    const title = document.getElementById('topicTitle').value;
+
+    const res = await fetch('/api/topics/create', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title })
+    });
+
+    if (res.ok) {
+      const data = await res.json();
+      if (typeof CURRENT_USERNAME !== 'undefined' && CURRENT_USERNAME) {
+        window.location.href = `/@${CURRENT_USERNAME}/${data.slug}/`;
+      } else {
+        window.location.reload();
+      }
+    } else {
+      alert('Failed to create topic');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- enable creating topics from home page via new modal and script
- provide reusable template and JavaScript for topic creation

## Testing
- `python -m pytest -q`
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68af2956b8148328a47d3522cfd2aeaa