### PR TITLE
Display related and suggested agenda events on topic page

### DIFF
--- a/semanticnews/topics/templates/topics/topics_detail.html
+++ b/semanticnews/topics/templates/topics/topics_detail.html
@@ -91,6 +91,36 @@
 
     <div class="col-12 col-lg-4">
 
+        <div class="card mt-3">
+          <div class="card-body">
+            <div class="card-title d-flex justify-content-between">
+                <h6 class="fs-5">
+                    {% trans "Related events" %}
+                </h6>
+            </div>
+            {% for event in related_events %}
+                {% include "agenda/event_list_item.html" with event=event %}
+            {% empty %}
+                <p class="text-secondary small mb-0">{% trans "No related events" %}</p>
+            {% endfor %}
+          </div>
+        </div>
+
+        <div class="card mt-3">
+          <div class="card-body">
+            <div class="card-title d-flex justify-content-between">
+                <h6 class="fs-5">
+                    {% trans "Suggested events" %}
+                </h6>
+            </div>
+            {% for event in suggested_events %}
+                {% include "agenda/event_list_item.html" with event=event %}
+            {% empty %}
+                <p class="text-secondary small mb-0">{% trans "No suggestions" %}</p>
+            {% endfor %}
+          </div>
+        </div>
+
         {% if timeline %}
 
             <div class="card mt-3">

--- a/semanticnews/topics/views.py
+++ b/semanticnews/topics/views.py
@@ -1,12 +1,35 @@
 from django.shortcuts import render, get_object_or_404
+from pgvector.django import L2Distance
+
+from semanticnews.agenda.models import Event
 from .models import Topic
 
 
 def topics_detail(request, slug, username):
     topic = get_object_or_404(
-        Topic, slug=slug,
+        Topic.objects.prefetch_related("events"),
+        slug=slug,
         created_by__username=username,
     )
-    return render(request, 'topics/topics_detail.html', {
-        'topic': topic,
-    })
+
+    related_events = topic.events.all()
+
+    if topic.embedding is not None:
+        suggested_events = (
+            Event.objects.exclude(topics=topic)
+            .exclude(embedding__isnull=True)
+            .annotate(distance=L2Distance("embedding", topic.embedding))
+            .order_by("distance")[:5]
+        )
+    else:
+        suggested_events = Event.objects.none()
+
+    return render(
+        request,
+        "topics/topics_detail.html",
+        {
+            "topic": topic,
+            "related_events": related_events,
+            "suggested_events": suggested_events,
+        },
+    )


### PR DESCRIPTION
## Summary
- Show agenda events already linked to a topic
- Suggest nearby events based on embedding distance
- Test topic detail view for related/suggested events

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68b0516afc148328bb834cf830886cd5