### PR TITLE
Add ability to link suggested events to topics

### DIFF
--- a/semanticnews/agenda/templates/agenda/event_list_item.html
+++ b/semanticnews/agenda/templates/agenda/event_list_item.html
@@ -1,4 +1,6 @@
 
+{% load i18n %}
+
 <div class="mb-3">
     <p class="text-secondary small mb-0">
         {{ event.date|date:"M d, Y" }}
@@ -15,5 +17,11 @@
             {% if not forloop.last %}&middot;{% endif %}
         {%  endfor %}
     </p>
+    {% if show_add %}
+        <form method="post" class="mt-2" action="{% url 'topics_add_event' username=topic.created_by.username slug=topic.slug event_uuid=event.uuid %}">
+            {% csrf_token %}
+            <button type="submit" class="btn btn-sm btn-outline-primary">{% trans "Add" %}</button>
+        </form>
+    {% endif %}
 </div>
 

--- a/semanticnews/topics/templates/topics/topics_detail.html
+++ b/semanticnews/topics/templates/topics/topics_detail.html
@@ -114,7 +114,7 @@
                 </h6>
             </div>
             {% for event in suggested_events %}
-                {% include "agenda/event_list_item.html" with event=event %}
+                {% include "agenda/event_list_item.html" with event=event show_add=True topic=topic %}
             {% empty %}
                 <p class="text-secondary small mb-0">{% trans "No suggestions" %}</p>
             {% endfor %}

--- a/semanticnews/urls.py
+++ b/semanticnews/urls.py
@@ -46,6 +46,7 @@ urlpatterns += i18n_patterns(
         name='event_list_year',
     ),
 
+    path('@<slug:username>/<slug:slug>/add-event/<uuid:event_uuid>/', topics_views.topic_add_event, name='topics_add_event'),
     path('@<slug:username>/<slug:slug>/', topics_views.topics_detail, name='topics_detail'),
 
     path('@<slug:username>', profiles_views.user_profile, name='user_profile'),


### PR DESCRIPTION
## Summary
- show an **Add** button next to suggested events on topic detail pages
- wire up view and route to attach an agenda event to a topic
- cover the new behavior with tests

## Testing
- `python manage.py test` *(fails: type "vector" does not exist)*

------
https://chatgpt.com/codex/tasks/task_b_68b0589682608328a86696d3d3414d93