### PR TITLE
Use async API for topic event edits

### DIFF
--- a/semanticnews/agenda/templates/agenda/event_list_item.html
+++ b/semanticnews/agenda/templates/agenda/event_list_item.html
@@ -1,7 +1,7 @@
 
 {% load i18n %}
 
-<div class="mb-3">
+<div class="mb-3" data-event-uuid="{{ event.uuid }}">
     <p class="text-secondary small mb-0">
         {{ event.date|date:"M d, Y" }}
         {% for category in event.categories.all %}
@@ -18,16 +18,22 @@
         {%  endfor %}
     </p>
     {% if show_add %}
-        <form method="post" class="mt-2" action="{% url 'topics_add_event' username=topic.created_by.username slug=topic.slug event_uuid=event.uuid %}">
-            {% csrf_token %}
-            <button type="submit" class="btn btn-sm btn-outline-primary">{% trans "Add" %}</button>
-        </form>
+        <button type="button"
+                class="btn btn-sm btn-outline-primary mt-2 add-event-btn"
+                data-event-uuid="{{ event.uuid }}"
+                data-add-label="{% trans 'Add' %}"
+                data-remove-label="{% trans 'Remove' %}">
+            {% trans "Add" %}
+        </button>
     {% endif %}
     {% if show_remove %}
-        <form method="post" class="mt-2" action="{% url 'topics_remove_event' username=topic.created_by.username slug=topic.slug event_uuid=event.uuid %}">
-            {% csrf_token %}
-            <button type="submit" class="btn btn-sm btn-outline-danger">{% trans "Remove" %}</button>
-        </form>
+        <button type="button"
+                class="btn btn-sm btn-outline-danger mt-2 remove-event-btn"
+                data-event-uuid="{{ event.uuid }}"
+                data-add-label="{% trans 'Add' %}"
+                data-remove-label="{% trans 'Remove' %}">
+            {% trans "Remove" %}
+        </button>
     {% endif %}
 </div>
 

--- a/semanticnews/topics/templates/topics/topics_detail.html
+++ b/semanticnews/topics/templates/topics/topics_detail.html
@@ -92,7 +92,7 @@
     <div class="col-12 col-lg-4">
 
         <div class="card mt-3">
-          <div class="card-body">
+          <div class="card-body" id="relatedEventsContainer" data-empty-message="{% trans 'No related events' %}">
             <div class="card-title d-flex justify-content-between">
                 <h6 class="fs-5">
                     {% trans "Related events" %}
@@ -101,13 +101,13 @@
             {% for event in related_events %}
                 {% include "agenda/event_list_item.html" with event=event show_remove=True topic=topic %}
             {% empty %}
-                <p class="text-secondary small mb-0">{% trans "No related events" %}</p>
+                <p class="text-secondary small mb-0 empty-msg">{% trans "No related events" %}</p>
             {% endfor %}
           </div>
         </div>
 
         <div class="card mt-3">
-          <div class="card-body">
+          <div class="card-body" id="suggestedEventsContainer" data-empty-message="{% trans 'No suggestions' %}">
             <div class="card-title d-flex justify-content-between">
                 <h6 class="fs-5">
                     {% trans "Suggested events" %}
@@ -116,7 +116,7 @@
             {% for event in suggested_events %}
                 {% include "agenda/event_list_item.html" with event=event show_add=True topic=topic %}
             {% empty %}
-                <p class="text-secondary small mb-0">{% trans "No suggestions" %}</p>
+                <p class="text-secondary small mb-0 empty-msg">{% trans "No suggestions" %}</p>
             {% endfor %}
           </div>
         </div>
@@ -174,5 +174,10 @@
 </div>
 
 
+{% endblock %}
+
+{% block extra_js %}
+    {{ block.super }}
+    <script src="{% static 'topics/topic_events.js' %}"></script>
 {% endblock %}
 

--- a/static/topics/topic_events.js
+++ b/static/topics/topic_events.js
@@ -1,0 +1,73 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const topicEl = document.querySelector('[data-topic-uuid]');
+  if (!topicEl) return;
+
+  const topicUuid = topicEl.dataset.topicUuid;
+  const relatedContainer = document.getElementById('relatedEventsContainer');
+  const suggestedContainer = document.getElementById('suggestedEventsContainer');
+
+  async function postJSON(url, payload) {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    if (!res.ok) throw new Error('Request failed');
+    return res.json();
+  }
+
+  function ensureEmptyMessage(container) {
+    const hasEvent = container.querySelector('[data-event-uuid]');
+    if (!hasEvent) {
+      let empty = container.querySelector('.empty-msg');
+      if (!empty) {
+        empty = document.createElement('p');
+        empty.className = 'text-secondary small mb-0 empty-msg';
+        empty.textContent = container.dataset.emptyMessage || '';
+        container.appendChild(empty);
+      }
+    } else {
+      const empty = container.querySelector('.empty-msg');
+      if (empty) empty.remove();
+    }
+  }
+
+  document.addEventListener('click', async (e) => {
+    const addBtn = e.target.closest('.add-event-btn');
+    const removeBtn = e.target.closest('.remove-event-btn');
+
+    if (addBtn) {
+      e.preventDefault();
+      const eventUuid = addBtn.dataset.eventUuid;
+      try {
+        await postJSON('/api/topics/add-event', { topic_uuid: topicUuid, event_uuid: eventUuid });
+        const wrapper = addBtn.closest('[data-event-uuid]');
+        if (!wrapper) return;
+        addBtn.classList.remove('btn-outline-primary', 'add-event-btn');
+        addBtn.classList.add('btn-outline-danger', 'remove-event-btn');
+        addBtn.textContent = addBtn.dataset.removeLabel || 'Remove';
+        relatedContainer.appendChild(wrapper);
+        ensureEmptyMessage(relatedContainer);
+        ensureEmptyMessage(suggestedContainer);
+      } catch (err) {
+        console.error(err);
+      }
+    } else if (removeBtn) {
+      e.preventDefault();
+      const eventUuid = removeBtn.dataset.eventUuid;
+      try {
+        await postJSON('/api/topics/remove-event', { topic_uuid: topicUuid, event_uuid: eventUuid });
+        const wrapper = removeBtn.closest('[data-event-uuid]');
+        if (!wrapper) return;
+        removeBtn.classList.remove('btn-outline-danger', 'remove-event-btn');
+        removeBtn.classList.add('btn-outline-primary', 'add-event-btn');
+        removeBtn.textContent = removeBtn.dataset.addLabel || 'Add';
+        suggestedContainer.appendChild(wrapper);
+        ensureEmptyMessage(relatedContainer);
+        ensureEmptyMessage(suggestedContainer);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- replace form submits with buttons to add and remove events via topic API
- dynamically move events between suggested and related lists without reloading
- wire topic detail page to new JS controller

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b05fedeb6c8328b3a6156777493e11