### PR TITLE
Restrict event controls to event owners

### DIFF
--- a/semanticnews/agenda/templates/agenda/event_list_item.html
+++ b/semanticnews/agenda/templates/agenda/event_list_item.html
@@ -17,7 +17,7 @@
             {% if not forloop.last %}&middot;{% endif %}
         {%  endfor %}
     </p>
-    {% if show_add %}
+    {% if show_add and request.user == event.created_by %}
         <button type="button"
                 class="btn btn-sm btn-outline-primary mt-2 add-event-btn"
                 data-event-uuid="{{ event.uuid }}"
@@ -26,7 +26,7 @@
             {% trans "Add" %}
         </button>
     {% endif %}
-    {% if show_remove %}
+    {% if show_remove and request.user == event.created_by %}
         <button type="button"
                 class="btn btn-sm btn-outline-danger mt-2 remove-event-btn"
                 data-event-uuid="{{ event.uuid }}"


### PR DESCRIPTION
## Summary
- Hide add/remove event buttons on topic detail pages unless the viewer created the event
- Test that event controls are only visible to event owners

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_b_68b06b8a672883288f2ee7d917fcd04b