### PR TITLE
Update topic timestamps on related changes

### DIFF
--- a/semanticnews/topics/apps.py
+++ b/semanticnews/topics/apps.py
@@ -12,3 +12,4 @@ class TopicsConfig(AppConfig):
         from .utils.arguments import models  # noqa: F401
         from .utils.contributors import models  # noqa: F401
         from .utils.keywords import models  # noqa: F401
+        from . import signals  # noqa: F401

--- a/semanticnews/topics/signals.py
+++ b/semanticnews/topics/signals.py
@@ -1,0 +1,40 @@
+from django.db.models.signals import post_save, post_delete, m2m_changed
+from django.dispatch import receiver
+from django.utils import timezone
+
+from .models import Topic, TopicEvent, TopicContent
+
+
+def touch_topic(topic_id):
+    """Update the ``updated_at`` timestamp for the given Topic."""
+    Topic.objects.filter(pk=topic_id).update(updated_at=timezone.now())
+
+
+@receiver([post_save, post_delete], sender=TopicEvent)
+def update_topic_timestamp_from_event(sender, instance, **kwargs):
+    touch_topic(instance.topic_id)
+
+
+@receiver([post_save, post_delete], sender=TopicContent)
+def update_topic_timestamp_from_content(sender, instance, **kwargs):
+    touch_topic(instance.topic_id)
+
+
+@receiver(m2m_changed, sender=Topic.events.through)
+def topic_events_m2m_changed(sender, instance, action, reverse, model, pk_set, **kwargs):
+    if action in {"post_add", "post_remove", "post_clear"}:
+        if reverse:
+            for pk in pk_set:
+                touch_topic(pk)
+        else:
+            touch_topic(instance.pk)
+
+
+@receiver(m2m_changed, sender=Topic.contents.through)
+def topic_contents_m2m_changed(sender, instance, action, reverse, model, pk_set, **kwargs):
+    if action in {"post_add", "post_remove", "post_clear"}:
+        if reverse:
+            for pk in pk_set:
+                touch_topic(pk)
+        else:
+            touch_topic(instance.pk)


### PR DESCRIPTION
## Summary
- update topic `updated_at` when events or contents are modified
- ensure topics app loads signal handlers
- test updated_at change for event and content relations

## Testing
- `python manage.py test semanticnews.topics.tests.TopicUpdatedAtTests -v 2`
- `python manage.py test -v 2` *(fails: FAILURES=1, ERRORS=6)*

------
https://chatgpt.com/codex/tasks/task_b_68b11a58f9348328b93370b2162228bd