### PR TITLE
Add topic recap generation endpoint and client trigger

### DIFF
--- a/semanticnews/topics/templates/topics/topics_detail.html
+++ b/semanticnews/topics/templates/topics/topics_detail.html
@@ -179,5 +179,6 @@
 {% block extra_js %}
     {{ block.super }}
     <script src="{% static 'topics/topic_events.js' %}"></script>
+    <script src="{% static 'topics/topic_recap.js' %}"></script>
 {% endblock %}
 

--- a/static/topics/topic_recap.js
+++ b/static/topics/topic_recap.js
@@ -1,0 +1,25 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('recapButton');
+  if (!btn) return;
+
+  const topicUuid = btn.dataset.topicUuid;
+
+  btn.addEventListener('click', async (e) => {
+    e.preventDefault();
+    btn.disabled = true;
+    try {
+      const res = await fetch('/api/topics/recap/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ topic_uuid: topicUuid })
+      });
+      if (!res.ok) throw new Error('Request failed');
+      const data = await res.json();
+      alert(data.recap);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      btn.disabled = false;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add `/topics/recap/create` API endpoint generating OpenAI-based recaps for a topic's related events and contents
- wire up recap button on topic detail page with JS to call new endpoint

## Testing
- `python manage.py test 2>&1 | tail -n 20` *(fails: connection to server at "localhost" (127.0.0.1) port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68b12397d64c83289a248999bbe1b1af