### PR TITLE
Render topic recap with markdown

### DIFF
--- a/semanticnews/topics/templates/topics/topics_detail.html
+++ b/semanticnews/topics/templates/topics/topics_detail.html
@@ -89,7 +89,7 @@
         <div class="card my-3" id="topicRecapContainer"{% if not latest_recap %} style="display: none;"{% endif %}>
             <div class="card-body">
                 <h6 class="fs-5">{% trans "Recap" %}</h6>
-                <div id="topicRecapText" style="white-space: pre-line;">{% if latest_recap %}{{ latest_recap.recap }}{% endif %}</div>
+                <div id="topicRecapText">{% if latest_recap %}{{ latest_recap.recap|markdownify }}{% endif %}</div>
             </div>
         </div>
 

--- a/semanticnews/topics/tests.py
+++ b/semanticnews/topics/tests.py
@@ -215,6 +215,22 @@ class TopicDetailViewTests(TestCase):
         self.assertIn("New recap", content)
         self.assertNotIn("Old recap", content)
 
+    @patch("semanticnews.topics.models.Topic.get_embedding", return_value=[0.0] * 1536)
+    @patch("semanticnews.agenda.models.Event.get_embedding", return_value=[0.0] * 1536)
+    def test_recap_rendered_as_markdown(self, mock_event_embedding, mock_topic_embedding):
+        """Recap text is rendered using the markdown filter."""
+
+        User = get_user_model()
+        user = User.objects.create_user("user", "user@example.com", "password")
+
+        topic = Topic.objects.create(title="My Topic", created_by=user)
+        TopicRecap.objects.create(topic=topic, recap="**Bold** text")
+
+        response = self.client.get(topic.get_absolute_url())
+        content = response.content.decode()
+
+        self.assertIn("<strong>Bold</strong> text", content)
+
 
 class TopicAddEventViewTests(TestCase):
     """Tests for adding suggested events to a topic via the view."""

--- a/static/topics/topic_recap.js
+++ b/static/topics/topic_recap.js
@@ -3,8 +3,6 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!btn) return;
 
   const topicUuid = btn.dataset.topicUuid;
-  const recapContainer = document.getElementById('topicRecapContainer');
-  const recapText = document.getElementById('topicRecapText');
 
   btn.addEventListener('click', async (e) => {
     e.preventDefault();
@@ -16,13 +14,8 @@ document.addEventListener('DOMContentLoaded', () => {
         body: JSON.stringify({ topic_uuid: topicUuid })
       });
       if (!res.ok) throw new Error('Request failed');
-      const data = await res.json();
-      if (recapText) {
-        recapText.textContent = data.recap;
-      }
-      if (recapContainer) {
-        recapContainer.style.display = '';
-      }
+      await res.json();
+      window.location.reload();
     } catch (err) {
       console.error(err);
     } finally {


### PR DESCRIPTION
## Summary
- Return raw Markdown from the recap creation API and persist it unchanged.
- Display recaps through the `markdownify` template filter and reload the page after recap generation to apply server-side rendering.

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68b127b40dd88328bb50cc293700f27b