### PR TITLE
feat: add websearch option for topic recaps

### DIFF
--- a/semanticnews/topics/agents.py
+++ b/semanticnews/topics/agents.py
@@ -289,12 +289,22 @@ class TopicRecapAgent:
         "Highlight the key entities by making them bold. "
     )
 
-    async def run(self, news):
-        agent = Agent(
+    async def run(self, news, websearch: bool = False):
+        kwargs = dict(
             name=self.name,
             instructions=self.instructions,
             output_type=TopicRecapSchema,
         )
+
+        if websearch:
+            kwargs["tools"] = [
+                WebSearchTool(
+                    user_location=UserLocation(country="TR", type="approximate"),
+                    search_context_size="low",
+                )
+            ]
+
+        agent = Agent(**kwargs)
 
         result = await Runner.run(agent, news)
 

--- a/semanticnews/topics/api.py
+++ b/semanticnews/topics/api.py
@@ -2,15 +2,13 @@ from ninja import NinjaAPI, Schema
 from ninja.errors import HttpError
 from typing import Optional
 
-from asgiref.sync import async_to_sync
-
 from semanticnews.agenda.models import Event
 
 from .models import Topic, TopicEvent
-from .agents import TopicRecapAgent
-from .utils.recaps.models import TopicRecap
+from .utils.recaps.api import router as recaps_router
 
 api = NinjaAPI(title="Topics API", urls_namespace="topics")
+api.add_router("/recap", recaps_router)
 
 
 class TopicCreateRequest(Schema):
@@ -188,56 +186,3 @@ def remove_event_from_topic(request, payload: TopicEventRemoveRequest):
     )
 
 
-class TopicRecapCreateRequest(Schema):
-    """Request body for creating a recap for a topic.
-
-    Attributes:
-        topic_uuid (str): UUID of the topic to recap.
-    """
-
-    topic_uuid: str
-
-
-class TopicRecapCreateResponse(Schema):
-    """Response returned after creating a recap."""
-
-    recap: str
-
-
-@api.post("/recap/create", response=TopicRecapCreateResponse)
-def create_recap(request, payload: TopicRecapCreateRequest):
-    """Generate and store a recap for a topic using OpenAI."""
-
-    user = getattr(request, "user", None)
-    if not user or not user.is_authenticated:
-        raise HttpError(401, "Unauthorized")
-
-    try:
-        topic = Topic.objects.get(uuid=payload.topic_uuid)
-    except Topic.DoesNotExist:
-        raise HttpError(404, "Topic not found")
-
-    # Build context from related events and contents
-    content_md = f"# {topic.title}\n\n"
-
-    events = topic.events.all()
-    if events:
-        content_md += "## Events\n\n"
-        for event in events:
-            content_md += f"- {event.title} ({event.date})\n"
-
-    contents = topic.contents.all()
-    if contents:
-        content_md += "\n## Contents\n\n"
-        for c in contents:
-            title = c.title or ""
-            text = c.markdown or ""
-            content_md += f"### {title}\n{text}\n\n"
-
-    agent = TopicRecapAgent()
-    response = async_to_sync(agent.run)(content_md)
-    recap_text = response.recap_en
-
-    TopicRecap.objects.create(topic=topic, recap=recap_text)
-
-    return TopicRecapCreateResponse(recap=recap_text)

--- a/semanticnews/topics/utils/recaps/api.py
+++ b/semanticnews/topics/utils/recaps/api.py
@@ -1,0 +1,60 @@
+from ninja import Router, Schema
+from ninja.errors import HttpError
+from asgiref.sync import async_to_sync
+
+from ...models import Topic
+from .models import TopicRecap
+from ...agents import TopicRecapAgent
+
+router = Router()
+
+
+class TopicRecapCreateRequest(Schema):
+    """Request body for creating a recap for a topic."""
+
+    topic_uuid: str
+    websearch: bool = False
+
+
+class TopicRecapCreateResponse(Schema):
+    """Response returned after creating a recap."""
+
+    recap: str
+
+
+@router.post("/create", response=TopicRecapCreateResponse)
+def create_recap(request, payload: TopicRecapCreateRequest):
+    """Generate and store a recap for a topic using OpenAI."""
+
+    user = getattr(request, "user", None)
+    if not user or not user.is_authenticated:
+        raise HttpError(401, "Unauthorized")
+
+    try:
+        topic = Topic.objects.get(uuid=payload.topic_uuid)
+    except Topic.DoesNotExist:
+        raise HttpError(404, "Topic not found")
+
+    content_md = f"# {topic.title}\n\n"
+
+    events = topic.events.all()
+    if events:
+        content_md += "## Events\n\n"
+        for event in events:
+            content_md += f"- {event.title} ({event.date})\n"
+
+    contents = topic.contents.all()
+    if contents:
+        content_md += "\n## Contents\n\n"
+        for c in contents:
+            title = c.title or ""
+            text = c.markdown or ""
+            content_md += f"### {title}\n{text}\n\n"
+
+    agent = TopicRecapAgent()
+    response = async_to_sync(agent.run)(content_md, websearch=payload.websearch)
+    recap_text = response.recap_en
+
+    TopicRecap.objects.create(topic=topic, recap=recap_text)
+
+    return TopicRecapCreateResponse(recap=recap_text)


### PR DESCRIPTION
## Summary
- allow recap generation to optionally use websearch
- move recap API under topics/utils/recaps

## Testing
- `pip install -q -r requirements.txt`
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68b137f929b88328a801d7e336bf24bb