### PR TITLE
Touch topic timestamp when recaps or images are created

### DIFF
--- a/semanticnews/topics/signals.py
+++ b/semanticnews/topics/signals.py
@@ -3,6 +3,8 @@ from django.dispatch import receiver
 from django.utils import timezone
 
 from .models import Topic, TopicEvent, TopicContent
+from .utils.recaps.models import TopicRecap
+from .utils.images.models import TopicImage
 
 
 def touch_topic(topic_id):
@@ -18,6 +20,17 @@ def update_topic_timestamp_from_event(sender, instance, **kwargs):
 @receiver([post_save, post_delete], sender=TopicContent)
 def update_topic_timestamp_from_content(sender, instance, **kwargs):
     touch_topic(instance.topic_id)
+
+
+@receiver([post_save, post_delete], sender=TopicRecap)
+def update_topic_timestamp_from_recap(sender, instance, **kwargs):
+    touch_topic(instance.topic_id)
+
+
+@receiver([post_save, post_delete], sender=TopicImage)
+def update_topic_timestamp_from_image(sender, instance, **kwargs):
+    if instance.topic_id:
+        touch_topic(instance.topic_id)
 
 
 @receiver(m2m_changed, sender=Topic.events.through)

--- a/semanticnews/topics/tests.py
+++ b/semanticnews/topics/tests.py
@@ -6,12 +6,14 @@ from django.test import TestCase
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django.utils import timezone
+from django.core.files.uploadedfile import SimpleUploadedFile
 
 from semanticnews.agenda.models import Event
 from semanticnews.contents.models import Content
 
 from .models import Topic
 from .utils.recaps.models import TopicRecap
+from .utils.images.models import TopicImage
 
 
 class CreateTopicAPITests(TestCase):
@@ -363,6 +365,53 @@ class TopicUpdatedAtTests(TestCase):
             content = Content.objects.create(url="https://example.com/a", content_type="article")
             mock_now.return_value = later
             topic.contents.add(content, through_defaults={"created_by": user})
+
+            topic.refresh_from_db()
+            self.assertNotEqual(initial, topic.updated_at)
+            self.assertEqual(topic.updated_at, later)
+
+    @patch("semanticnews.topics.models.Topic.get_embedding", return_value=[0.0] * 1536)
+    def test_updated_at_changes_when_recap_added(self, mock_topic_embedding):
+        User = get_user_model()
+        user = User.objects.create_user("user", "user@example.com", "password")
+
+        start = timezone.now()
+        later = start + timedelta(days=1)
+
+        with patch("django.utils.timezone.now") as mock_now:
+            mock_now.return_value = start
+            topic = Topic.objects.create(title="My Topic", created_by=user)
+            initial = topic.updated_at
+
+            mock_now.return_value = later
+            TopicRecap.objects.create(topic=topic, recap="A recap")
+
+            topic.refresh_from_db()
+            self.assertNotEqual(initial, topic.updated_at)
+            self.assertEqual(topic.updated_at, later)
+
+    @patch("semanticnews.topics.models.Topic.get_embedding", return_value=[0.0] * 1536)
+    def test_updated_at_changes_when_image_added(self, mock_topic_embedding):
+        User = get_user_model()
+        user = User.objects.create_user("user", "user@example.com", "password")
+
+        start = timezone.now()
+        later = start + timedelta(days=1)
+
+        with patch("django.utils.timezone.now") as mock_now:
+            mock_now.return_value = start
+            topic = Topic.objects.create(title="My Topic", created_by=user)
+            initial = topic.updated_at
+
+            mock_now.return_value = later
+            image_bytes = (
+                b"\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00\xff\xff\xff!"
+                b"\xf9\x04\x01\x00\x00\x00\x00,\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02D\x01\x00;"
+            )
+            TopicImage.objects.create(
+                topic=topic,
+                image=SimpleUploadedFile("test.gif", image_bytes, content_type="image/gif"),
+            )
 
             topic.refresh_from_db()
             self.assertNotEqual(initial, topic.updated_at)


### PR DESCRIPTION
## Summary
- Update `Topic.updated_at` when a `TopicRecap` or `TopicImage` is saved or deleted
- Add tests ensuring recaps and images bump a topic's `updated_at` timestamp

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_b_68b15c6803c08328a2723336f40b8085