### PR TITLE
Add topic status update endpoint and publish control

### DIFF
--- a/semanticnews/topics/api.py
+++ b/semanticnews/topics/api.py
@@ -97,9 +97,12 @@ def set_topic_status(request, payload: TopicStatusUpdateRequest):
         raise HttpError(401, "Unauthorized")
 
     try:
-        topic = Topic.objects.get(uuid=payload.topic_uuid, created_by=user)
+        topic = Topic.objects.get(uuid=payload.topic_uuid)
     except Topic.DoesNotExist:
         raise HttpError(404, "Topic not found")
+
+    if topic.created_by != user:
+        raise HttpError(403, "Forbidden")
 
     valid_statuses = {choice[0] for choice in Topic._meta.get_field("status").choices}
     if payload.status not in valid_statuses:

--- a/semanticnews/topics/templates/topics/topics_detail.html
+++ b/semanticnews/topics/templates/topics/topics_detail.html
@@ -45,7 +45,7 @@
     </div>
 
     <div class="ms-auto mt-auto pb-2">
-        {% if topic.status == 'draft' %}
+        {% if topic.status == 'draft' and user == topic.created_by %}
         <button class="btn btn-outline-primary btn-sm" id="publishTopicBtn">
             {% trans "Publish" %}
         </button>
@@ -237,5 +237,6 @@
     {{ block.super }}
     <script src="{% static 'topics/topic_events.js' %}"></script>
     <script src="{% static 'topics/topic_recap.js' %}"></script>
+    <script src="{% static 'topics/topic_publish.js' %}"></script>
 {% endblock %}
 

--- a/semanticnews/topics/tests.py
+++ b/semanticnews/topics/tests.py
@@ -187,7 +187,7 @@ class SetTopicStatusAPITests(TestCase):
             "/api/topics/set-status", payload, content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 403)
         topic.refresh_from_db()
         self.assertEqual(topic.status, "draft")
 

--- a/static/topics/topic_publish.js
+++ b/static/topics/topic_publish.js
@@ -1,0 +1,25 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('publishTopicBtn');
+  if (!btn) return;
+  const topicEl = document.querySelector('[data-topic-uuid]');
+  if (!topicEl) return;
+  const topicUuid = topicEl.dataset.topicUuid;
+
+  btn.addEventListener('click', async (e) => {
+    e.preventDefault();
+    btn.disabled = true;
+    try {
+      const res = await fetch('/api/topics/set-status', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ topic_uuid: topicUuid, status: 'published' })
+      });
+      if (!res.ok) throw new Error('Request failed');
+      await res.json();
+      window.location.reload();
+    } catch (err) {
+      console.error(err);
+      btn.disabled = false;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- allow updating a topic's status via `/api/topics/set-status`
- show publish button only for draft topics owned by the viewer
- add client script to call new publish endpoint

## Testing
- `python manage.py test semanticnews.topics.tests.SetTopicStatusAPITests --verbosity 2`


------
https://chatgpt.com/codex/tasks/task_b_68b1aa96cd74832893d5fc19aa7063bd