### PR TITLE
Hook up topic archiving

### DIFF
--- a/semanticnews/agenda/templates/agenda/event_list_item.html
+++ b/semanticnews/agenda/templates/agenda/event_list_item.html
@@ -21,7 +21,8 @@
         <button type="button"
                 class="btn btn-sm btn-outline-primary mt-2 add-event-btn"
                 data-add-label="{% trans 'Add' %}"
-                data-remove-label="{% trans 'Remove' %}">
+                data-remove-label="{% trans 'Remove' %}"
+                {% if archived %}disabled{% endif %}>
             {% trans "Add" %}
         </button>
     {% endif %}
@@ -29,7 +30,8 @@
         <button type="button"
                 class="btn btn-sm btn-outline-danger mt-2 remove-event-btn"
                 data-add-label="{% trans 'Add' %}"
-                data-remove-label="{% trans 'Remove' %}">
+                data-remove-label="{% trans 'Remove' %}"
+                {% if archived %}disabled{% endif %}>
             {% trans "Remove" %}
         </button>
     {% endif %}

--- a/semanticnews/topics/templates/topics/topics_detail.html
+++ b/semanticnews/topics/templates/topics/topics_detail.html
@@ -75,19 +75,23 @@
         <div class="d-flex justify-content-between">
 
             <div class="gap-2">
-                <button class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#recapModal">
+                <button class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#recapModal"{% if topic.status == 'archived' %} disabled{% endif %}>
                     {% trans "Recap" %}
                 </button>
             </div>
 
             <div class="gap-2">
                 {% if topic.status == 'draft' %}
-                    <button class="btn btn-outline-primary btn-sm" id="publishTopicBtn">
+                    <button class="btn btn-outline-primary btn-sm" id="publishTopicBtn" data-status="published">
                         {% trans "Publish" %}
                     </button>
                 {% elif topic.status == 'published' %}
-                    <button class="btn btn-outline-primary btn-sm" id="publishTopicBtn">
+                    <button class="btn btn-outline-primary btn-sm" id="publishTopicBtn" data-status="archived">
                         {% trans "Archive" %}
+                    </button>
+                {% elif topic.status == 'archived' %}
+                    <button class="btn btn-outline-primary btn-sm" id="publishTopicBtn" data-status="published">
+                        {% trans "Unarchive" %}
                     </button>
                 {% endif %}
             </div>
@@ -124,7 +128,7 @@
                 </h6>
             </div>
             {% for event in related_events %}
-                {% include "agenda/event_list_item.html" with event=event show_remove=True topic=topic %}
+                {% include "agenda/event_list_item.html" with event=event show_remove=True topic=topic archived=topic.status == 'archived' %}
             {% empty %}
                 <p class="text-secondary small mb-0 empty-msg">{% trans "No related events" %}</p>
             {% endfor %}
@@ -139,7 +143,7 @@
                 </h6>
             </div>
             {% for event in suggested_events %}
-                {% include "agenda/event_list_item.html" with event=event show_add=True topic=topic %}
+                {% include "agenda/event_list_item.html" with event=event show_add=True topic=topic archived=topic.status == 'archived' %}
             {% empty %}
                 <p class="text-secondary small mb-0 empty-msg">{% trans "No suggestions" %}</p>
             {% endfor %}

--- a/static/topics/topic_publish.js
+++ b/static/topics/topic_publish.js
@@ -8,11 +8,12 @@ document.addEventListener('DOMContentLoaded', () => {
   btn.addEventListener('click', async (e) => {
     e.preventDefault();
     btn.disabled = true;
+    const status = btn.dataset.status;
     try {
       const res = await fetch('/api/topics/set-status', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ topic_uuid: topicUuid, status: 'published' })
+        body: JSON.stringify({ topic_uuid: topicUuid, status })
       });
       if (!res.ok) throw new Error('Request failed');
       await res.json();


### PR DESCRIPTION
## Summary
- Disable edit controls when a topic is archived and show an Unarchive option
- Pass status data to archive/publish button and submit via topics set-status API

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68b2756d88908328be25dcbc36476be9