### PR TITLE
Add topic cloning feature

### DIFF
--- a/semanticnews/topics/templates/topics/topics_detail.html
+++ b/semanticnews/topics/templates/topics/topics_detail.html
@@ -38,6 +38,14 @@
                    class="text-info-emphasis bi bi-link copy-link ms-1"
                    data-url="{{ topic.get_absolute_url }}"></a>
 
+                {% if topic.created_by != user %}
+                    <a href="{% url 'topics_clone' slug=topic.slug username=topic.created_by.username %}"
+                       class="btn btn-outline-primary btn-sm ms-1"
+                       data-bs-toggle="tooltip" data-bs-title="{% trans "Clone topic" %}">
+                        {% trans "Clone" %}
+                    </a>
+                {% endif %}
+
             </small>
 
         </h1>

--- a/semanticnews/urls.py
+++ b/semanticnews/urls.py
@@ -48,6 +48,7 @@ urlpatterns += i18n_patterns(
 
     path('@<slug:username>/<slug:slug>/add-event/<uuid:event_uuid>/', topics_views.topic_add_event, name='topics_add_event'),
     path('@<slug:username>/<slug:slug>/remove-event/<uuid:event_uuid>/', topics_views.topic_remove_event, name='topics_remove_event'),
+    path('@<slug:username>/<slug:slug>/clone/', topics_views.topic_clone, name='topics_clone'),
     path('@<slug:username>/<slug:slug>/', topics_views.topics_detail, name='topics_detail'),
 
     path('@<slug:username>', profiles_views.user_profile, name='user_profile'),


### PR DESCRIPTION
## Summary
- allow users to clone another user's topic along with events, contents, recaps, images, and keywords
- expose clone endpoint and UI button on topic detail page
- add tests for cloning behavior

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: fe_sendauth: no password supplied)*

------
https://chatgpt.com/codex/tasks/task_b_68b7ed81b7608328a2bce6c02c52d109