### PR TITLE
Add MCP context modal and API endpoint

### DIFF
--- a/semanticnews/topics/api.py
+++ b/semanticnews/topics/api.py
@@ -6,9 +6,11 @@ from semanticnews.agenda.models import Event
 
 from .models import Topic, TopicEvent
 from .utils.recaps.api import router as recaps_router
+from .utils.mcps.api import router as mcps_router
 
 api = NinjaAPI(title="Topics API", urls_namespace="topics")
 api.add_router("/recap", recaps_router)
+api.add_router("/mcp", mcps_router)
 
 
 class TopicCreateRequest(Schema):

--- a/semanticnews/topics/templates/topics/mcps/button.html
+++ b/semanticnews/topics/templates/topics/mcps/button.html
@@ -5,7 +5,9 @@
   </button>
   <ul class="dropdown-menu">
     {% for server in mcp_servers %}
-      <li><button type="button" class="dropdown-item mcp-server-link" data-url="{{ server.url }}">{{ server.name }}</button></li>
+      <li>
+        <button type="button" class="dropdown-item mcp-server-link" data-id="{{ server.id }}" data-description="{{ server.description|escape }}">{{ server.name }}</button>
+      </li>
     {% empty %}
       <li><span class="dropdown-item-text text-secondary">{% trans "No MCP servers" %}</span></li>
     {% endfor %}

--- a/semanticnews/topics/templates/topics/mcps/modal.html
+++ b/semanticnews/topics/templates/topics/mcps/modal.html
@@ -1,0 +1,19 @@
+{% load i18n %}
+<div class="modal fade" id="mcpModal" tabindex="-1" aria-labelledby="mcpModalLabel" aria-hidden="true" data-topic-uuid="{{ topic.uuid }}">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h1 class="modal-title fs-5" id="mcpModalLabel">{% trans "Context" %}</h1>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans 'Close' %}"></button>
+      </div>
+      <div class="modal-body">
+        <p id="mcpDescription"></p>
+        <pre id="mcpContext" class="mt-3"></pre>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Close" %}</button>
+        <button type="button" class="btn btn-primary" id="mcpFetchBtn">{% trans "Fetch" %}</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/semanticnews/topics/templates/topics/topics_detail.html
+++ b/semanticnews/topics/templates/topics/topics_detail.html
@@ -210,6 +210,7 @@
 </div>
 
 
+{% include "topics/mcps/modal.html" %}
 {% include "topics/recaps/modal.html" %}
 
 {% endblock %}

--- a/semanticnews/topics/utils/mcps/api.py
+++ b/semanticnews/topics/utils/mcps/api.py
@@ -1,0 +1,53 @@
+from ninja import Router, Schema
+from ninja.errors import HttpError
+import requests
+
+from ...models import Topic
+from .models import MCPServer
+
+router = Router()
+
+
+class MCPContextRequest(Schema):
+    """Request body for fetching context from an MCP server."""
+
+    topic_uuid: str
+    server_id: int
+
+
+class MCPContextResponse(Schema):
+    """Response returned after fetching context."""
+
+    context: str
+
+
+@router.post("/context", response=MCPContextResponse)
+def fetch_context(request, payload: MCPContextRequest):
+    """Fetch extra context for a topic from an MCP server."""
+
+    user = getattr(request, "user", None)
+    if not user or not user.is_authenticated:
+        raise HttpError(401, "Unauthorized")
+
+    try:
+        topic = Topic.objects.get(uuid=payload.topic_uuid)
+    except Topic.DoesNotExist:
+        raise HttpError(404, "Topic not found")
+
+    try:
+        server = MCPServer.objects.get(id=payload.server_id, active=True)
+    except MCPServer.DoesNotExist:
+        raise HttpError(404, "Server not found")
+
+    try:
+        res = requests.post(
+            server.url,
+            json={"topic": topic.title, "uuid": str(topic.uuid)},
+            headers=server.headers or {},
+        )
+        res.raise_for_status()
+        data = res.json()
+    except Exception as exc:  # pragma: no cover - network errors
+        raise HttpError(502, "MCP server error") from exc
+
+    return MCPContextResponse(context=data.get("context", ""))

--- a/semanticnews/topics/utils/mcps/static/topics/mcps/mcp_context.js
+++ b/semanticnews/topics/utils/mcps/static/topics/mcps/mcp_context.js
@@ -1,10 +1,39 @@
 document.addEventListener('DOMContentLoaded', () => {
+  const modalEl = document.getElementById('mcpModal');
+  if (!modalEl) return;
+  const modal = new bootstrap.Modal(modalEl);
+  const descriptionEl = document.getElementById('mcpDescription');
+  const contextEl = document.getElementById('mcpContext');
+  const fetchBtn = document.getElementById('mcpFetchBtn');
+  let currentServerId = null;
+
   document.querySelectorAll('.mcp-server-link').forEach((btn) => {
     btn.addEventListener('click', () => {
-      const url = btn.dataset.url;
-      if (url) {
-        window.open(url, '_blank');
-      }
+      currentServerId = btn.dataset.id;
+      descriptionEl.textContent = btn.dataset.description || '';
+      contextEl.textContent = '';
+      fetchBtn.disabled = false;
+      modal.show();
     });
+  });
+
+  fetchBtn.addEventListener('click', async () => {
+    if (!currentServerId) return;
+    fetchBtn.disabled = true;
+    const topicUuid = modalEl.dataset.topicUuid;
+    try {
+      const res = await fetch('/api/topics/mcp/context', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ topic_uuid: topicUuid, server_id: currentServerId })
+      });
+      if (!res.ok) throw new Error('Request failed');
+      const data = await res.json();
+      contextEl.textContent = data.context;
+    } catch (err) {
+      console.error(err);
+    } finally {
+      fetchBtn.disabled = false;
+    }
   });
 });

--- a/semanticnews/topics/utils/mcps/tests.py
+++ b/semanticnews/topics/utils/mcps/tests.py
@@ -1,3 +1,49 @@
+from django.contrib.auth import get_user_model
 from django.test import TestCase
+from unittest.mock import MagicMock, patch
 
-# Create your tests here.
+from semanticnews.topics.models import Topic
+from .models import MCPServer
+
+
+class MCPContextAPITests(TestCase):
+    """Tests for the MCP context API endpoint."""
+
+    @patch("semanticnews.topics.utils.mcps.api.requests.post")
+    def test_fetches_context(self, mock_post):
+        User = get_user_model()
+        user = User.objects.create_user("user", "user@example.com", "password")
+        self.client.force_login(user)
+
+        topic = Topic.objects.create(title="My Topic", created_by=user)
+        server = MCPServer.objects.create(name="Server", url="http://example.com", description="Desc")
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"context": "Extra"}
+        mock_post.return_value = mock_response
+
+        payload = {"topic_uuid": str(topic.uuid), "server_id": server.id}
+        response = self.client.post(
+            "/api/topics/mcp/context", payload, content_type="application/json"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"context": "Extra"})
+        mock_post.assert_called_once_with(
+            server.url,
+            json={"topic": topic.title, "uuid": str(topic.uuid)},
+            headers=server.headers,
+        )
+
+    def test_requires_authentication(self):
+        User = get_user_model()
+        user = User.objects.create_user("user", "user@example.com", "password")
+        topic = Topic.objects.create(title="My Topic", created_by=user)
+        server = MCPServer.objects.create(name="Server", url="http://example.com")
+
+        payload = {"topic_uuid": str(topic.uuid), "server_id": server.id}
+        response = self.client.post(
+            "/api/topics/mcp/context", payload, content_type="application/json"
+        )
+
+        self.assertEqual(response.status_code, 401)


### PR DESCRIPTION
## Summary
- add MCP context API and hook into main topics API
- show MCP server description in a modal with fetch button
- update front-end script to retrieve context and display in modal
- test MCP context API behavior

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68b97e2df804832893d3830599814a59