### PR TITLE
Fix topic-keyword migration dependency error

### DIFF
--- a/semanticnews/topics/migrations/0007_keyword_topickeyword_keyword_topics.py
+++ b/semanticnews/topics/migrations/0007_keyword_topickeyword_keyword_topics.py
@@ -8,9 +8,15 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
+    # The Keyword model was originally part of the ``topics`` app and was
+    # later extracted into its own ``keywords`` app. Older databases may have
+    # already applied this migration before the new app existed which caused
+    # Django to complain about an inconsistent migration history.  Removing the
+    # explicit dependency on ``keywords`` allows those installations to run
+    # ``makemigrations``/``migrate`` again without having to fake apply the
+    # initial keywords migration.
     dependencies = [
         ('topics', '0006_remove_topic_categories_and_more'),
-        ('keywords', '0001_initial'),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 


### PR DESCRIPTION
## Summary
- remove explicit dependency on `keywords` from `topics` migration 0007 to avoid inconsistent migration history after refactor

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68b9dbb4d84c83289f8f2310bfa50e65