### PR TITLE
Fix missing keywords dependency in topics migration

### DIFF
--- a/semanticnews/topics/migrations/0007_keyword_topickeyword_keyword_topics.py
+++ b/semanticnews/topics/migrations/0007_keyword_topickeyword_keyword_topics.py
@@ -8,15 +8,15 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    # The Keyword model was originally part of the ``topics`` app and was
-    # later extracted into its own ``keywords`` app. Older databases may have
-    # already applied this migration before the new app existed which caused
-    # Django to complain about an inconsistent migration history.  Removing the
-    # explicit dependency on ``keywords`` allows those installations to run
-    # ``makemigrations``/``migrate`` again without having to fake apply the
-    # initial keywords migration.
+    # The ``Keyword`` model originally lived in the ``topics`` app and was later
+    # extracted into its own ``keywords`` app.  In order for the foreign key
+    # references below to resolve when applying migrations from a fresh
+    # database, we must depend on the initial migration of the ``keywords`` app.
+    # Without this dependency Django raises a ``ValueError`` claiming the
+    # ``keywords`` app is not installed because the model state is missing.
     dependencies = [
         ('topics', '0006_remove_topic_categories_and_more'),
+        ('keywords', '0001_initial'),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 


### PR DESCRIPTION
## Summary
- ensure topics migration depends on initial keywords migration

## Testing
- `python manage.py check`
- `python manage.py migrate --noinput` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68b9deb0a63c8328bbeba418d47777a1