### PR TITLE
Register missing models with admin site

### DIFF
--- a/semanticnews/agenda/admin.py
+++ b/semanticnews/agenda/admin.py
@@ -5,7 +5,7 @@ from django.urls import path
 from django.utils.safestring import mark_safe
 from slugify import slugify
 
-from .models import Event, Locality, Category, Source
+from .models import Event, Locality, Category, Source, Description
 from .forms import EventSuggestForm
 from .api import suggest_events, AgendaEventResponse
 
@@ -193,3 +193,9 @@ class CategoryAdmin(admin.ModelAdmin):
 class SourceAdmin(admin.ModelAdmin):
     list_display = ['url', 'get_domain']
     search_fields = ['url']
+
+
+@admin.register(Description)
+class DescriptionAdmin(admin.ModelAdmin):
+    list_display = ['event', 'created_by', 'created_at']
+    search_fields = ['event__title', 'description']

--- a/semanticnews/contents/admin.py
+++ b/semanticnews/contents/admin.py
@@ -4,7 +4,7 @@ from django.db.models import Count, Q
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 
-from .models import Source, Content
+from .models import Source, Content, ContentEvent
 
 
 # ---- Custom list filters -----------------------------------------------------
@@ -191,3 +191,10 @@ class ContentAdmin(admin.ModelAdmin):
         except Exception:
             first = "(unavailable)"
         return mark_safe(f"<code>[{first}{' …' if len(obj.embedding or []) > 16 else ''}]</code>")
+
+
+@admin.register(ContentEvent)
+class ContentEventAdmin(admin.ModelAdmin):
+    list_display = ('content', 'event', 'source', 'relevance', 'pinned')
+    list_filter = ('source', 'pinned')
+    search_fields = ('content__title', 'event__title')

--- a/semanticnews/entities/admin.py
+++ b/semanticnews/entities/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import Entity
+from .models import Entity, Description, EntityAlias
 
 
 @admin.register(Entity)
@@ -8,3 +8,15 @@ class KeywordAdmin(admin.ModelAdmin):
     search_fields = ("name", "disambiguation", "slug")
     ordering = ("name",)
     readonly_fields = ("created_at", "updated_at")
+
+
+@admin.register(Description)
+class DescriptionAdmin(admin.ModelAdmin):
+    list_display = ("entity", "created_by", "created_at")
+    search_fields = ("entity__name", "description")
+
+
+@admin.register(EntityAlias)
+class EntityAliasAdmin(admin.ModelAdmin):
+    list_display = ("name", "entity")
+    search_fields = ("name", "entity__name")

--- a/semanticnews/topics/admin.py
+++ b/semanticnews/topics/admin.py
@@ -43,3 +43,10 @@ class TopicEntityAdmin(admin.ModelAdmin):
     list_filter = ("created_at",)
     raw_id_fields = ("topic", "entity", "created_by")
     readonly_fields = ("created_at",)
+
+
+@admin.register(TopicEvent)
+class TopicEventAdmin(admin.ModelAdmin):
+    list_display = ('topic', 'event', 'source', 'relevance', 'pinned')
+    list_filter = ('source', 'pinned')
+    search_fields = ('topic__title', 'event__title')

--- a/semanticnews/users/admin.py
+++ b/semanticnews/users/admin.py
@@ -1,3 +1,15 @@
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 
-# Register your models here.
+from .models import User, UserBookmark
+
+
+@admin.register(User)
+class UserAdmin(BaseUserAdmin):
+    pass
+
+
+@admin.register(UserBookmark)
+class UserBookmarkAdmin(admin.ModelAdmin):
+    list_display = ('user', 'topic', 'created_at')
+    search_fields = ('user__username', 'topic__title')


### PR DESCRIPTION
## Summary
- expose all models in Django admin across apps
- include minimal ModelAdmin classes for association models and descriptions

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68ba5cfc21448328a4019383a7649f4a