### PR TITLE
Fix templates referencing missing login_form route

### DIFF
--- a/semanticnews/contents/sources/youtube/templates/youtube/video_chunk_item.html
+++ b/semanticnews/contents/sources/youtube/templates/youtube/video_chunk_item.html
@@ -32,9 +32,10 @@
     </a>
 
     {# Anonymous user => login #}
-    <a href="{% url 'login_form' %}" data-bs-toggle="tooltip" data-bs-title="{% trans "Login to add content" %}"
-       class="anonymous-only d-none small"
-    >{% trans "Add to topic" %}</a>
+    <a href="{% url 'login' %}" data-bs-toggle="tooltip" data-bs-title="{% trans "Login to add content" %}"
+       class="anonymous-only d-none small">
+        {% trans "Add to topic" %}
+    </a>
 
 </div>
 

--- a/semanticnews/templates/registration/password_reset_complete.html
+++ b/semanticnews/templates/registration/password_reset_complete.html
@@ -15,7 +15,7 @@
     </p>
 
     <p>
-        <a href="{% url 'login_form' %}">Log in</a>
+        <a href="{% url 'login' %}">Log in</a>
     </p>
 
 

--- a/semanticnews/templates/registration/registration_form.html
+++ b/semanticnews/templates/registration/registration_form.html
@@ -38,7 +38,7 @@
 
     <p>
         {% trans "Already have an account?" %}
-        <a href="{% url 'login_form' %}?next={{ request.GET.next }}">{% trans "Login here" %}</a>.
+        <a href="{% url 'login' %}?next={{ request.GET.next }}">{% trans "Login here" %}</a>.
     </p>
 
 {% endblock %}

--- a/semanticnews/templates/search_results.html
+++ b/semanticnews/templates/search_results.html
@@ -33,9 +33,10 @@
         </button>
 
         {# Anonymous user => login #}
-            <a href="{% url 'login_form' %}" data-bs-toggle="tooltip" data-bs-title="{% trans "Login to create a topic" %}"
-               class="anonymous-only d-none btn btn-outline-secondary btn-sm"
-            >{% trans "Create new topic" %}</a>
+        <a href="{% url 'login' %}" data-bs-toggle="tooltip" data-bs-title="{% trans "Login to create a topic" %}"
+           class="anonymous-only d-none btn btn-outline-secondary btn-sm">
+            {% trans "Create new topic" %}
+        </a>
     </div>
 
 </div>


### PR DESCRIPTION
## Summary
- Replace outdated `login_form` URL references with `login` across templates
- Ensure anonymous users are directed to the proper login page when performing actions like creating topics or adding content

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68bac1a105a08328bd0659141e788162