### PR TITLE
Fix logout link in navbar user dropdown

### DIFF
--- a/semanticnews/templates/base.html
+++ b/semanticnews/templates/base.html
@@ -158,9 +158,12 @@
                         </li>
 
                         <li>
-                            <a href="{% url 'logout' %}" class="dropdown-item">
-                                {% trans "Logout" %}
-                            </a>
+                            <form method="post" action="{% url 'logout' %}">
+                                {% csrf_token %}
+                                <button type="submit" class="dropdown-item">
+                                    {% trans "Logout" %}
+                                </button>
+                            </form>
                         </li>
 
                     </ul>


### PR DESCRIPTION
## Summary
- fix logout link by submitting a POST request

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68bac37d3cbc8328b59c3461759dd8fd