### PR TITLE
feat: refine event list view UI

### DIFF
--- a/semanticnews/agenda/templates/agenda/event_list.html
+++ b/semanticnews/agenda/templates/agenda/event_list.html
@@ -2,35 +2,43 @@
 
 {% load static i18n humanize markdown_extras %}
 
-{% block title %}{{ topic.title }}{% endblock %}
+{% block title %}
+    {% if period.granularity == "day" %}
+        {{ start|date:"F j, Y" }}
+    {% elif period.granularity == "month" %}
+        {{ start|date:"F Y" }}
+    {% else %}
+        {{ period.year }}
+    {% endif %}
+{% endblock %}
 
 
 {% block content %}
 
 <div class="container">
 
-    {% if user.is_authenticated %}
-    <button id="addEventBtn" class="btn btn-primary mb-3">{% trans "Add event" %}</button>
-    {% endif %}
-
-    <div class="row h-100">
-
-        <div class="col-12 col-md-8">
-
-            {% for event in events %}
-
-                <h2 class="fs-4">{{ event.title }}</h2>
-
-            {% endfor %}
-
-        </div>
-
-        <div class="col-12 col-md-4">
-
-
-        </div>
-
+    <div class="d-flex justify-content-between align-items-center mb-2">
+        <h1 class="fs-3 mb-0">
+            {% if period.granularity == "day" %}
+                {{ start|date:"F j, Y" }}
+            {% elif period.granularity == "month" %}
+                {{ start|date:"F Y" }}
+            {% else %}
+                {{ period.year }}
+            {% endif %}
+        </h1>
+        {% if user.is_authenticated %}
+        <button id="addEventBtn" class="btn btn-sm btn-outline-secondary" title="{% trans 'Add event' %}">
+            <i class="bi bi-plus-lg"></i>
+        </button>
+        {% endif %}
     </div>
+
+    {% for event in events %}
+        {% include "agenda/event_list_item.html" %}
+    {% empty %}
+        <p class="text-muted">{% trans "No events" %}</p>
+    {% endfor %}
 
 </div>
 
@@ -43,6 +51,7 @@
 {% block extra_js %}
     {{ block.super }}
     {% if user.is_authenticated %}
+    {{ exclude_events|json_script:"exclude-events" }}
     <script src="{% static 'agenda/event_modal.js' %}"></script>
     {% endif %}
 {% endblock %}

--- a/semanticnews/agenda/views.py
+++ b/semanticnews/agenda/views.py
@@ -95,10 +95,18 @@ def event_list(request, year, month=None, day=None):
     except EmptyPage:
         events = paginator.page(paginator.num_pages)
 
+    exclude_events = [
+        {"title": ev.title, "date": ev.date.isoformat()} for ev in qs
+    ]
+
+    localities = Locality.objects.all().order_by("-is_default", "name")
+
     context = {
         "events": events,
         "period": period,   # helpful for headings/breadcrumbs
         "start": start,
         "end": end,
+        "exclude_events": exclude_events,
+        "localities": localities,
     }
     return render(request, "agenda/event_list.html", context)


### PR DESCRIPTION
## Summary
- Revise agenda event list page to show each event via shared list item template with links to details
- Style add-event button like home and detail views, and include period heading
- Pass localities and existing events to template to support suggestion modal

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68bad6aad27c8328aee139b69673ca87