### PR TITLE
Filter topic listings to published status

### DIFF
--- a/semanticnews/profiles/views.py
+++ b/semanticnews/profiles/views.py
@@ -15,7 +15,7 @@ def user_profile(request, username):
     topics = (Topic.objects
               .filter(Q(created_by=user) |
                       Q(contents__created_by=user))
-              .exclude(status='r').distinct()).order_by('-updated_at')
+              .filter(status='published').distinct()).order_by('-updated_at')
 
     topic_content = TopicContent.objects.filter(created_by=user).select_related(
         'topicarticle__article',

--- a/semanticnews/topics/models.py
+++ b/semanticnews/topics/models.py
@@ -106,11 +106,11 @@ class Topic(models.Model):
 
     @cached_property
     def get_similar_topics(self, limit=5):
-        return Topic.objects\
-                   .exclude(id=self.id)\
-                   .exclude(embedding__isnull=True)\
-                   .exclude(status='r')\
-                   .order_by(L2Distance('embedding', self.embedding))[:limit]
+        return (Topic.objects
+                .exclude(id=self.id)
+                .exclude(embedding__isnull=True)
+                .filter(status='published')
+                .order_by(L2Distance('embedding', self.embedding))[:limit])
 
 
 class TopicEvent(models.Model):

--- a/semanticnews/users/views.py
+++ b/semanticnews/users/views.py
@@ -1,14 +1,19 @@
 from django.shortcuts import render, get_object_or_404
+from django.db.models import Q
+from django.contrib.auth.models import User
+
+from ..topics.models import Topic, TopicContent
+from ..profiles.models import Profile
 
 
 def user_profile(request, username):
     user = get_object_or_404(User, username=username)
     topics = (Topic.objects
               .filter(Q(created_by=user) |
-                      Q(contents__added_by=user))
-              .exclude(status='r').distinct()).order_by('-updated_at')
+                      Q(contents__created_by=user))
+              .filter(status='published').distinct()).order_by('-updated_at')
 
-    topic_content = TopicContent.objects.filter(added_by=user).select_related(
+    topic_content = TopicContent.objects.filter(created_by=user).select_related(
         'topicarticle__article',
         'topicvideo__video_chunk',
     )

--- a/semanticnews/views.py
+++ b/semanticnews/views.py
@@ -7,7 +7,7 @@ def home(request):
     recent_events = Event.objects.filter(status='published').order_by('-date')[:5]
     return render(request, 'home.html', {
         'events': recent_events,
-        'topics': Topic.objects.all(),
+        'topics': Topic.objects.filter(status='published'),
     })
 
 
@@ -27,7 +27,7 @@ def search_results(request):
 
     if search_term.embedding is not None:
         similar_topics = Topic.objects.filter(embedding__isnull=False) \
-                             .filter(status='p') \
+                             .filter(status='published') \
                              .order_by(L2Distance('embedding', search_term.embedding))
         recommended_keywords = (
             Keyword.objects


### PR DESCRIPTION
## Summary
- Only show published topics on the home page and search results
- Restrict profile and user topic lists to published entries
- Limit similar topics to published status

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68badba0b1948328add1481d49f4c767