### PR TITLE
Add prev/next navigation to event list views

### DIFF
--- a/semanticnews/agenda/templates/agenda/event_list.html
+++ b/semanticnews/agenda/templates/agenda/event_list.html
@@ -27,11 +27,21 @@
                 {{ period.year }}
             {% endif %}
         </h1>
-        {% if user.is_authenticated %}
-        <button id="addEventBtn" class="btn btn-sm btn-outline-secondary" title="{% trans 'Add event' %}">
-            <i class="bi bi-plus-lg"></i>
-        </button>
-        {% endif %}
+        <div class="d-flex align-items-center">
+            <div class="btn-group me-2">
+                <a href="{{ prev_url }}" class="btn btn-sm btn-outline-secondary" title="{% trans 'Previous' %}">
+                    <i class="bi bi-chevron-left"></i>
+                </a>
+                <a href="{{ next_url }}" class="btn btn-sm btn-outline-secondary" title="{% trans 'Next' %}">
+                    <i class="bi bi-chevron-right"></i>
+                </a>
+            </div>
+            {% if user.is_authenticated %}
+            <button id="addEventBtn" class="btn btn-sm btn-outline-secondary" title="{% trans 'Add event' %}">
+                <i class="bi bi-plus-lg"></i>
+            </button>
+            {% endif %}
+        </div>
     </div>
 
     {% if categories %}


### PR DESCRIPTION
## Summary
- show previous/next links on date-based event list pages
- compute navigation URLs in event list view for day, month and year periods

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68bbd0966c04832882c74c8dfd4ab5c6