### PR TITLE
Add topic creation button on event detail page

### DIFF
--- a/semanticnews/agenda/templates/agenda/event_detail.html
+++ b/semanticnews/agenda/templates/agenda/event_detail.html
@@ -48,7 +48,15 @@
 
         <div class="col-12 col-md-4">
 
-            <h2 class="fs-5">{% trans "Topics" %}</h2>
+            <div class="d-flex justify-content-between align-items-center mb-2">
+                <h2 class="fs-5 mb-0">{% trans "Topics" %}</h2>
+                {% if user.is_authenticated %}
+                <button id="addTopicBtn" class="btn btn-sm btn-outline-secondary" title="{% trans 'Add topic' %}">
+                    <i class="bi bi-plus-lg"></i>
+                </button>
+                {% endif %}
+            </div>
+
             <ul class="list-unstyled">
                 {% for topic in event.topics.all %}
                     <li><a href="{{ topic.get_absolute_url }}">{{ topic.title }}</a></li>
@@ -61,6 +69,7 @@
     </div>
 </div>
 
+{% include "topics/create_topic_modal.html" %}
 {% if user.is_authenticated %}
 {% include "agenda/event_modal.html" %}
 {% endif %}
@@ -74,4 +83,5 @@
     <script src="{% static 'agenda/event_modal.js' %}"></script>
     {% endif %}
     <script src="{% static 'agenda/category_filter.js' %}"></script>
+    {% include "topics/create_topic_js.html" %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add "+" button beside Topics heading on event detail page to open topic creation modal
- Include topic creation modal and JavaScript on event detail page

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68bbf4809b188328baf4c069c093428d