### PR TITLE
Add AI suggestions tab to topic creation modal

### DIFF
--- a/semanticnews/agenda/templates/agenda/event_detail.html
+++ b/semanticnews/agenda/templates/agenda/event_detail.html
@@ -51,7 +51,7 @@
             <div class="d-flex justify-content-between align-items-center mb-2">
                 <h2 class="fs-5 mb-0">{% trans "Topics" %}</h2>
                 {% if user.is_authenticated %}
-                <button id="addTopicBtn" class="btn btn-sm btn-outline-secondary" title="{% trans 'Add topic' %}">
+                <button id="addTopicBtn" data-event-title="{{ event.title }}" class="btn btn-sm btn-outline-secondary" title="{% trans 'Add topic' %}">
                     <i class="bi bi-plus-lg"></i>
                 </button>
                 {% endif %}

--- a/semanticnews/templates/topics/create_topic_modal.html
+++ b/semanticnews/templates/topics/create_topic_modal.html
@@ -2,22 +2,43 @@
 <div class="modal fade" id="createTopicModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
-            <form id="createTopicForm">
-                <div class="modal-header">
-                    <h5 class="modal-title">{% trans "Create new topic" %}</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                </div>
-                <div class="modal-body">
-                    <div class="mb-3">
-                        <label for="topicTitle" class="form-label">{% trans "Title" %}</label>
-                        <input type="text" class="form-control" id="topicTitle" required>
+            <div class="modal-header">
+                <h5 class="modal-title">{% trans "Create new topic" %}</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <ul class="nav nav-tabs mb-3" id="topicModalTabs" role="tablist">
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link active" id="topic-create-tab" data-bs-toggle="tab" data-bs-target="#topicCreatePane" type="button" role="tab">{% trans "Create manually" %}</button>
+                    </li>
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link" id="topic-ai-tab" data-bs-toggle="tab" data-bs-target="#topicAIPane" type="button" role="tab">{% trans "AI suggestions" %}</button>
+                    </li>
+                </ul>
+                <div class="tab-content">
+                    <div class="tab-pane fade show active" id="topicCreatePane" role="tabpanel">
+                        <form id="createTopicForm">
+                            <div class="mb-3">
+                                <label for="topicTitle" class="form-label">{% trans "Title" %}</label>
+                                <input type="text" class="form-control" id="topicTitle" required>
+                            </div>
+                            <div class="modal-footer px-0">
+                                <button type="submit" class="btn btn-primary">{% trans "Create topic" %}</button>
+                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Close" %}</button>
+                            </div>
+                        </form>
+                    </div>
+                    <div class="tab-pane fade" id="topicAIPane" role="tabpanel">
+                        <form id="suggestTopicsForm">
+                            <div class="mb-3">
+                                <label for="suggestTopicsAbout" class="form-label">{% trans "Suggest topics about" %}</label>
+                                <input type="text" class="form-control" id="suggestTopicsAbout" value="{% trans 'Current agenda' %}">
+                            </div>
+                        </form>
                     </div>
                 </div>
-                <div class="modal-footer">
-                    <button type="submit" class="btn btn-primary">{% trans "Create topic" %}</button>
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Close" %}</button>
-                </div>
-            </form>
+            </div>
         </div>
     </div>
 </div>
+

--- a/semanticnews/topics/static/topics/create_topic_modal.js
+++ b/semanticnews/topics/static/topics/create_topic_modal.js
@@ -6,13 +6,23 @@ document.addEventListener('DOMContentLoaded', function () {
   const modal = new bootstrap.Modal(modalElement);
   const form = document.getElementById('createTopicForm');
   const btn = document.getElementById('addTopicBtn');
+  const suggestField = document.getElementById('suggestTopicsAbout');
+  const createTab = document.getElementById('topic-create-tab');
+  const defaultSuggestion = suggestField ? suggestField.value : '';
 
-  if (btn) {
-    btn.addEventListener('click', () => {
-      form.reset();
-      modal.show();
-    });
-  }
+    if (btn) {
+      btn.addEventListener('click', () => {
+        form.reset();
+        if (suggestField) {
+          const t = btn.dataset.eventTitle || defaultSuggestion;
+          suggestField.value = t;
+        }
+        if (createTab) {
+          new bootstrap.Tab(createTab).show();
+        }
+        modal.show();
+      });
+    }
 
   form.addEventListener('submit', async function (e) {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- Add AI suggestions tab to the topic creation modal with default "Current agenda" prompt
- Prefill suggestions with event title when opened from event details
- Ensure modal opens to the manual creation tab with proper reset

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68bbf86fa51483288be3e5cad99abde4