### PR TITLE
Add AI topic suggestion workflow to topic modal

### DIFF
--- a/semanticnews/templates/topics/create_topic_modal.html
+++ b/semanticnews/templates/topics/create_topic_modal.html
@@ -34,6 +34,12 @@
                                 <label for="suggestTopicsAbout" class="form-label">{% trans "Suggest topics about" %}</label>
                                 <input type="text" class="form-control" id="suggestTopicsAbout" value="{% trans 'Current agenda' %}">
                             </div>
+                            <button type="button" class="btn btn-secondary mb-3" id="fetchTopicSuggestions">{% trans "Fetch suggestions" %}</button>
+                            <div id="suggestedTopicsList" class="list-group mb-3 d-none"></div>
+                            <div class="mb-3">
+                                <label for="suggestedTopicTitle" class="form-label">{% trans "Title" %}</label>
+                                <input type="text" class="form-control" id="suggestedTopicTitle" required>
+                            </div>
                             <div class="modal-footer px-0">
                                 <button type="submit" class="btn btn-primary">{% trans "Create topic" %}</button>
                                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Close" %}</button>

--- a/semanticnews/topics/static/topics/create_topic_modal.js
+++ b/semanticnews/topics/static/topics/create_topic_modal.js
@@ -8,6 +8,9 @@ document.addEventListener('DOMContentLoaded', function () {
   const btn = document.getElementById('addTopicBtn');
   const suggestForm = document.getElementById('suggestTopicsForm');
   const suggestField = document.getElementById('suggestTopicsAbout');
+  const fetchBtn = document.getElementById('fetchTopicSuggestions');
+  const suggestedList = document.getElementById('suggestedTopicsList');
+  const suggestedTitle = document.getElementById('suggestedTopicTitle');
   const createTab = document.getElementById('topic-create-tab');
   const defaultSuggestion = suggestField ? suggestField.value : '';
 
@@ -19,6 +22,11 @@ document.addEventListener('DOMContentLoaded', function () {
         const t = btn.getAttribute('data-event-title') || defaultSuggestion;
         suggestField.value = t;
       }
+      if (suggestedList) {
+        suggestedList.innerHTML = '';
+        suggestedList.classList.add('d-none');
+      }
+      if (suggestedTitle) suggestedTitle.value = '';
       if (createTab) {
         new bootstrap.Tab(createTab).show();
       }
@@ -26,16 +34,12 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   }
 
-  form.addEventListener('submit', async function (e) {
-    e.preventDefault();
-    const title = document.getElementById('topicTitle').value;
-
+  async function createTopic(title) {
     const res = await fetch('/api/topics/create', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ title })
     });
-
     if (res.ok) {
       const data = await res.json();
       if (typeof CURRENT_USERNAME !== 'undefined' && CURRENT_USERNAME) {
@@ -46,5 +50,50 @@ document.addEventListener('DOMContentLoaded', function () {
     } else {
       alert('Failed to create topic');
     }
+  }
+
+  form.addEventListener('submit', async function (e) {
+    e.preventDefault();
+    const title = document.getElementById('topicTitle').value;
+    await createTopic(title);
   });
+
+  if (suggestForm) {
+    suggestForm.addEventListener('submit', async function (e) {
+      e.preventDefault();
+      const title = suggestedTitle ? suggestedTitle.value : '';
+      if (title) {
+        await createTopic(title);
+      }
+    });
+  }
+
+  if (fetchBtn && suggestField && suggestedList) {
+    fetchBtn.addEventListener('click', async () => {
+      suggestedList.innerHTML = '<p>Loading suggestions...</p>';
+      suggestedList.classList.remove('d-none');
+      try {
+        const about = suggestField.value;
+        const res = await fetch(`/api/topics/suggest?about=${encodeURIComponent(about)}`);
+        const data = await res.json();
+        if (Array.isArray(data) && data.length) {
+          suggestedList.innerHTML = '';
+          data.forEach((title) => {
+            const item = document.createElement('button');
+            item.type = 'button';
+            item.className = 'list-group-item list-group-item-action';
+            item.textContent = title;
+            item.addEventListener('click', () => {
+              if (suggestedTitle) suggestedTitle.value = title;
+            });
+            suggestedList.appendChild(item);
+          });
+        } else {
+          suggestedList.innerHTML = '<p>No suggestions found.</p>';
+        }
+      } catch (err) {
+        suggestedList.innerHTML = '<p>Error loading suggestions.</p>';
+      }
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- add "fetch suggestions" button and suggestion list to create-topic modal's AI tab
- fetch topics from `/api/topics/suggest` and populate a selectable list
- allow creating topics from selected suggestion or custom title

## Testing
- `python manage.py test` *(fails: connection to PostgreSQL at "localhost" was refused)*

------
https://chatgpt.com/codex/tasks/task_b_68bc22d2bbb88328980af870d3f1a1b3