### PR TITLE
Fix topic suggestion fetch call

### DIFF
--- a/semanticnews/topics/static/topics/create_topic_modal.js
+++ b/semanticnews/topics/static/topics/create_topic_modal.js
@@ -74,7 +74,12 @@ function initCreateTopicModal() {
       suggestedList.classList.remove('d-none');
       try {
         const about = suggestField.value;
-        const res = await fetch(`/api/topics/suggest?about=${encodeURIComponent(about)}`);
+        const res = await fetch('/api/topics/suggest', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ about })
+        });
+        if (!res.ok) throw new Error('Failed to fetch');
         const data = await res.json();
         if (Array.isArray(data) && data.length) {
           suggestedList.innerHTML = '';


### PR DESCRIPTION
## Summary
- Ensure "Fetch suggestions" button invokes `suggest_topics` API using POST

## Testing
- `python manage.py test semanticnews.topics.test_api_suggest_topics -v 2`
- `python manage.py test -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68bc337c50688328ada5c448f8102f96