### PR TITLE
refactor: simplify topic modal

### DIFF
--- a/semanticnews/templates/topics/create_topic_modal.html
+++ b/semanticnews/templates/topics/create_topic_modal.html
@@ -7,46 +7,19 @@
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
-                <ul class="nav nav-tabs mb-3" id="topicModalTabs" role="tablist">
-                    <li class="nav-item" role="presentation">
-                        <button class="nav-link active" id="topic-create-tab" data-bs-toggle="tab" data-bs-target="#topicCreatePane" type="button" role="tab">{% trans "Create manually" %}</button>
-                    </li>
-                    <li class="nav-item" role="presentation">
-                        <button class="nav-link" id="topic-ai-tab" data-bs-toggle="tab" data-bs-target="#topicAIPane" type="button" role="tab">{% trans "AI suggestions" %}</button>
-                    </li>
-                </ul>
-                <div class="tab-content">
-                    <div class="tab-pane fade show active" id="topicCreatePane" role="tabpanel">
-                        <form id="createTopicForm">
-                            <div class="mb-3">
-                                <label for="topicTitle" class="form-label">{% trans "Title" %}</label>
-                                <input type="text" class="form-control" id="topicTitle" required>
-                            </div>
-                            <div class="modal-footer px-0">
-                                <button type="submit" class="btn btn-primary">{% trans "Create topic" %}</button>
-                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Close" %}</button>
-                            </div>
-                        </form>
+                <form id="createTopicForm">
+                    <input type="hidden" id="suggestTopicsAbout" value="{% trans 'Current agenda' %}">
+                    <div class="mb-3">
+                        <label for="topicTitle" class="form-label">{% trans "Title" %}</label>
+                        <input type="text" class="form-control" id="topicTitle" required>
                     </div>
-                    <div class="tab-pane fade" id="topicAIPane" role="tabpanel">
-                        <form id="suggestTopicsForm">
-                            <div class="mb-3">
-                                <label for="suggestTopicsAbout" class="form-label">{% trans "Suggest topics about" %}</label>
-                                <input type="text" class="form-control" id="suggestTopicsAbout" value="{% trans 'Current agenda' %}">
-                            </div>
-                            <button type="button" class="btn btn-secondary mb-3" id="fetchTopicSuggestions">{% trans "Get suggestions" %}</button>
-                            <div id="suggestedTopicsList" class="list-group mb-3 d-none"></div>
-                            <div class="mb-3">
-                                <label for="suggestedTopicTitle" class="form-label">{% trans "Title" %}</label>
-                                <input type="text" class="form-control" id="suggestedTopicTitle" required>
-                            </div>
-                            <div class="modal-footer px-0">
-                                <button type="submit" class="btn btn-primary">{% trans "Create topic" %}</button>
-                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Close" %}</button>
-                            </div>
-                        </form>
+                    <div id="suggestedTopicsList" class="list-group mb-3 d-none"></div>
+                    <div class="modal-footer px-0">
+                        <button type="button" class="btn btn-secondary float-start me-auto" id="fetchTopicSuggestions">{% trans "Get suggestions" %}</button>
+                        <button type="submit" class="btn btn-primary">{% trans "Create topic" %}</button>
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Close" %}</button>
                     </div>
-                </div>
+                </form>
             </div>
         </div>
     </div>

--- a/semanticnews/topics/static/topics/create_topic_modal.js
+++ b/semanticnews/topics/static/topics/create_topic_modal.js
@@ -6,18 +6,15 @@ function initCreateTopicModal() {
   const modal = new bootstrap.Modal(modalElement);
   const form = document.getElementById('createTopicForm');
   const btn = document.getElementById('addTopicBtn');
-  const suggestForm = document.getElementById('suggestTopicsForm');
   const suggestField = document.getElementById('suggestTopicsAbout');
   const fetchBtn = document.getElementById('fetchTopicSuggestions');
   const suggestedList = document.getElementById('suggestedTopicsList');
-  const suggestedTitle = document.getElementById('suggestedTopicTitle');
-  const createTab = document.getElementById('topic-create-tab');
+  const titleInput = document.getElementById('topicTitle');
   const defaultSuggestion = suggestField ? suggestField.value : '';
 
   if (btn) {
     btn.addEventListener('click', () => {
       if (form) form.reset();
-      if (suggestForm) suggestForm.reset();
       if (suggestField) {
         const t = btn.getAttribute('data-event-title') || defaultSuggestion;
         suggestField.value = t;
@@ -25,10 +22,6 @@ function initCreateTopicModal() {
       if (suggestedList) {
         suggestedList.innerHTML = '';
         suggestedList.classList.add('d-none');
-      }
-      if (suggestedTitle) suggestedTitle.value = '';
-      if (createTab) {
-        new bootstrap.Tab(createTab).show();
       }
       modal.show();
     });
@@ -54,19 +47,9 @@ function initCreateTopicModal() {
 
   form.addEventListener('submit', async function (e) {
     e.preventDefault();
-    const title = document.getElementById('topicTitle').value;
+    const title = titleInput ? titleInput.value : '';
     await createTopic(title);
   });
-
-  if (suggestForm) {
-    suggestForm.addEventListener('submit', async function (e) {
-      e.preventDefault();
-      const title = suggestedTitle ? suggestedTitle.value : '';
-      if (title) {
-        await createTopic(title);
-      }
-    });
-  }
 
   if (fetchBtn && suggestField && suggestedList) {
     fetchBtn.addEventListener('click', async () => {
@@ -89,7 +72,7 @@ function initCreateTopicModal() {
             item.className = 'list-group-item list-group-item-action';
             item.textContent = title;
             item.addEventListener('click', () => {
-              if (suggestedTitle) suggestedTitle.value = title;
+              if (titleInput) titleInput.value = title;
             });
             suggestedList.appendChild(item);
           });


### PR DESCRIPTION
## Summary
- unify manual and AI suggestion tabs into single topic creation form
- move suggestion button to modal footer and hide about field
- update JavaScript to populate title from fetched suggestions

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68bc632d46448328a290256b30a2c270