### PR TITLE
Hide unpublished topics in event detail

### DIFF
--- a/semanticnews/agenda/templates/agenda/event_detail.html
+++ b/semanticnews/agenda/templates/agenda/event_detail.html
@@ -58,7 +58,7 @@
             </div>
 
             <ul class="list-unstyled">
-                {% for topic in event.topics.all %}
+                {% for topic in topics %}
                     <li><a href="{{ topic.get_absolute_url }}">{{ topic.title }}</a></li>
                 {% empty %}
                     <li class="text-muted">{% trans "No topics" %}</li>

--- a/semanticnews/agenda/views.py
+++ b/semanticnews/agenda/views.py
@@ -4,9 +4,11 @@ import calendar
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
+from django.db.models import Prefetch
 from pgvector.django import L2Distance
 
 from .models import Event, Locality, Category
+from semanticnews.topics.models import Topic
 
 
 DISTANCE_THRESHOLD = 1
@@ -14,7 +16,9 @@ DISTANCE_THRESHOLD = 1
 
 def event_detail(request, year, month, day, slug):
     obj = get_object_or_404(
-        Event.objects.prefetch_related("topics"),
+        Event.objects.prefetch_related(
+            Prefetch("topics", queryset=Topic.objects.filter(status="published"))
+        ),
         slug=slug,
         date__year=year,
         date__month=month,
@@ -51,6 +55,7 @@ def event_detail(request, year, month, day, slug):
         "agenda/event_detail.html",
         {
             "event": obj,
+            "topics": obj.topics.all(),
             "similar_events": similar_events,
             "exclude_events": exclude_events,
             "localities": localities,


### PR DESCRIPTION
## Summary
- Only prefetch and render topics with `published` status on event detail pages.
- Template updated to use prefiltered topics list.

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68bc861276088328bdbe4e571ddfba1b