### PR TITLE
Add topic selection dropdown for events

### DIFF
--- a/semanticnews/agenda/templates/agenda/event_detail.html
+++ b/semanticnews/agenda/templates/agenda/event_detail.html
@@ -51,7 +51,7 @@
             <div class="d-flex justify-content-between align-items-center mb-2">
                 <h2 class="fs-5 mb-0">{% trans "Topics" %}</h2>
                 {% if user.is_authenticated %}
-                <button id="addTopicBtn" data-event-title="{{ event.title }}" class="btn btn-sm btn-outline-secondary" title="{% trans 'Add topic' %}">
+                <button data-event-title="{{ event.title }}" class="btn btn-sm btn-outline-secondary add-topic-btn" title="{% trans 'Add topic' %}">
                     <i class="bi bi-plus-lg"></i>
                 </button>
                 {% endif %}

--- a/semanticnews/agenda/templates/agenda/event_list.html
+++ b/semanticnews/agenda/templates/agenda/event_list.html
@@ -62,6 +62,7 @@
 
 {% if user.is_authenticated %}
 {% include "agenda/event_modal.html" %}
+{% include "topics/create_topic_modal.html" %}
 {% endif %}
 
 {% endblock %}
@@ -71,6 +72,7 @@
     {% if user.is_authenticated %}
     {{ exclude_events|json_script:"exclude-events" }}
     <script src="{% static 'agenda/event_modal.js' %}"></script>
+    {% include "topics/create_topic_js.html" %}
     {% endif %}
     <script src="{% static 'agenda/category_filter.js' %}"></script>
 {% endblock %}

--- a/semanticnews/agenda/templates/agenda/event_list_item.html
+++ b/semanticnews/agenda/templates/agenda/event_list_item.html
@@ -17,14 +17,26 @@
             {% if not forloop.last %}&middot;{% endif %}
         {%  endfor %}
     </p>
-    {% if show_add and request.user == event.created_by %}
-        <button type="button"
-                class="btn btn-sm btn-outline-primary mt-2 add-event-btn"
-                data-add-label="{% trans 'Add' %}"
-                data-remove-label="{% trans 'Remove' %}"
-                {% if archived %}disabled{% endif %}>
-            {% trans "Add" %}
-        </button>
+    {% if request.user.is_authenticated %}
+        <div class="dropdown d-inline mt-2">
+            <button class="btn btn-sm btn-outline-primary dropdown-toggle"
+                    type="button" data-bs-toggle="dropdown" aria-expanded="false"
+                    {% if archived %}disabled{% endif %}>
+                {% trans "Add" %}
+            </button>
+            <ul class="dropdown-menu">
+                {% if topic %}
+                <li><a class="dropdown-item add-to-topic" href="#" data-topic-uuid="{{ topic.uuid }}" data-event-uuid="{{ event.uuid }}">{% trans "Add to this topic" %}</a></li>
+                <li><hr class="dropdown-divider"></li>
+                {% endif %}
+                {% for t in user_topics %}
+                <li><a class="dropdown-item add-to-topic" href="#" data-topic-uuid="{{ t.uuid }}" data-event-uuid="{{ event.uuid }}">{{ t.title }}</a></li>
+                {% empty %}
+                {% endfor %}
+                <li><hr class="dropdown-divider"></li>
+                <li><a class="dropdown-item add-topic-btn" href="#" data-event-title="{{ event.title }}">{% trans "Create new topic" %}</a></li>
+            </ul>
+        </div>
     {% endif %}
     {% if show_remove and request.user == event.created_by %}
         <button type="button"

--- a/semanticnews/agenda/views.py
+++ b/semanticnews/agenda/views.py
@@ -50,17 +50,20 @@ def event_detail(request, year, month, day, slug):
 
     localities = Locality.objects.all().order_by("-is_default", "name")
 
+    context = {
+        "event": obj,
+        "topics": obj.topics.all(),
+        "similar_events": similar_events,
+        "exclude_events": exclude_events,
+        "localities": localities,
+        "categories": categories,
+    }
+    if request.user.is_authenticated:
+        context["user_topics"] = Topic.objects.filter(created_by=request.user)
     return render(
         request,
         "agenda/event_detail.html",
-        {
-            "event": obj,
-            "topics": obj.topics.all(),
-            "similar_events": similar_events,
-            "exclude_events": exclude_events,
-            "localities": localities,
-            "categories": categories,
-        },
+        context,
     )
 
 
@@ -168,4 +171,6 @@ def event_list(request, year, month=None, day=None):
         "prev_url": prev_url,
         "next_url": next_url,
     }
+    if request.user.is_authenticated:
+        context["user_topics"] = Topic.objects.filter(created_by=request.user)
     return render(request, "agenda/event_list.html", context)

--- a/semanticnews/templates/home.html
+++ b/semanticnews/templates/home.html
@@ -14,7 +14,7 @@
             <div class="d-flex justify-content-between align-items-center mb-2">
                 <h2 class="fs-5 mb-0">{%  trans "Topics" %}</h2>
                 {% if user.is_authenticated %}
-                <button id="addTopicBtn" class="btn btn-sm btn-outline-secondary" title="{% trans 'Add topic' %}">
+                <button class="btn btn-sm btn-outline-secondary add-topic-btn" title="{% trans 'Add topic' %}">
                     <i class="bi bi-plus-lg"></i>
                 </button>
                 {% endif %}

--- a/semanticnews/topics/api.py
+++ b/semanticnews/topics/api.py
@@ -166,6 +166,9 @@ def add_event_to_topic(request, payload: TopicEventAddRequest):
     except Topic.DoesNotExist:
         raise HttpError(404, "Topic not found")
 
+    if topic.created_by != user:
+        topic = topic.clone_for_user(user)
+
     try:
         event = Event.objects.get(uuid=payload.event_uuid)
     except Event.DoesNotExist:

--- a/semanticnews/topics/static/topics/add_event_dropdown.js
+++ b/semanticnews/topics/static/topics/add_event_dropdown.js
@@ -1,0 +1,24 @@
+// Handles adding events to topics from the dropdown menu
+
+document.addEventListener('click', async function (e) {
+  const link = e.target.closest('.add-to-topic');
+  if (!link) return;
+  e.preventDefault();
+  const topicUuid = link.getAttribute('data-topic-uuid');
+  const eventUuid = link.getAttribute('data-event-uuid');
+  try {
+    const res = await fetch('/api/topics/add-event', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ topic_uuid: topicUuid, event_uuid: eventUuid })
+    });
+    if (!res.ok) throw new Error('Request failed');
+    const data = await res.json();
+    const currentTopic = document.querySelector('[data-topic-uuid]');
+    if (currentTopic && currentTopic.dataset.topicUuid === data.topic_uuid) {
+      window.location.reload();
+    }
+  } catch (err) {
+    console.error(err);
+  }
+});

--- a/semanticnews/topics/static/topics/create_topic_modal.js
+++ b/semanticnews/topics/static/topics/create_topic_modal.js
@@ -5,14 +5,14 @@ function initCreateTopicModal() {
   if (!modalElement) return;
   const modal = new bootstrap.Modal(modalElement);
   const form = document.getElementById('createTopicForm');
-  const btn = document.getElementById('addTopicBtn');
+  const btns = document.querySelectorAll('.add-topic-btn');
   const suggestField = document.getElementById('suggestTopicsAbout');
   const fetchBtn = document.getElementById('fetchTopicSuggestions');
   const suggestedList = document.getElementById('suggestedTopicsList');
   const titleInput = document.getElementById('topicTitle');
   const defaultSuggestion = suggestField ? suggestField.value : '';
 
-  if (btn) {
+  btns.forEach((btn) => {
     btn.addEventListener('click', () => {
       if (form) form.reset();
       if (suggestField) {
@@ -25,7 +25,7 @@ function initCreateTopicModal() {
       }
       modal.show();
     });
-  }
+  });
 
   async function createTopic(title) {
     const res = await fetch('/api/topics/create', {

--- a/semanticnews/topics/templates/topics/create_topic_js.html
+++ b/semanticnews/topics/templates/topics/create_topic_js.html
@@ -3,3 +3,4 @@
   const CURRENT_USERNAME = "{{ request.user.username|escapejs }}";
 </script>
 <script src="{% static 'topics/create_topic_modal.js' %}"></script>
+<script src="{% static 'topics/add_event_dropdown.js' %}"></script>

--- a/semanticnews/topics/templates/topics/topics_detail.html
+++ b/semanticnews/topics/templates/topics/topics_detail.html
@@ -212,6 +212,7 @@
 
 {% include "topics/mcps/modal.html" %}
 {% include "topics/recaps/modal.html" %}
+{% include "topics/create_topic_modal.html" %}
 
 {% endblock %}
 
@@ -219,6 +220,7 @@
     {{ block.super }}
     <script src="{% static 'topics/topic_events.js' %}"></script>
     <script src="{% static 'topics/topic_publish.js' %}"></script>
+    {% include "topics/create_topic_js.html" %}
     {% include "topics/recaps/scripts.html" %}
     {% include "topics/mcps/scripts.html" %}
 {% endblock %}

--- a/semanticnews/views.py
+++ b/semanticnews/views.py
@@ -5,10 +5,13 @@ from .topics.models import Topic
 
 def home(request):
     recent_events = Event.objects.filter(status='published').order_by('-date')[:5]
-    return render(request, 'home.html', {
+    context = {
         'events': recent_events,
         'topics': Topic.objects.filter(status='published'),
-    })
+    }
+    if request.user.is_authenticated:
+        context['user_topics'] = Topic.objects.filter(created_by=request.user)
+    return render(request, 'home.html', context)
 
 
 def search_results(request):


### PR DESCRIPTION
## Summary
- Replace single Add button with topic selection dropdown on event cards
- Clone non-owned topics when relating events through the API
- Enable creating topics from multiple entry points and add dropdown script

## Testing
- `DJANGO_SETTINGS_MODULE=semanticnews.settings pytest` *(fails: Apps aren't loaded yet)*
- `python manage.py test` *(fails: connection to server at "localhost" (127.0.0.1) refused)*

------
https://chatgpt.com/codex/tasks/task_b_68bd105caa6c8328bdcc6ade80b3d762