### PR TITLE
Hide Add dropdown for events already in topic

### DIFF
--- a/semanticnews/agenda/templates/agenda/event_list_item.html
+++ b/semanticnews/agenda/templates/agenda/event_list_item.html
@@ -18,6 +18,7 @@
         {%  endfor %}
     </p>
     {% if request.user.is_authenticated and show_add|default:True %}
+        {% if not topic or event not in topic.events.all %}
         <div class="dropdown d-inline">
             <button class="btn btn-sm btn-outline-primary dropdown-toggle"
                     type="button" data-bs-toggle="dropdown" aria-expanded="false"
@@ -39,6 +40,7 @@
                 <li><a class="dropdown-item small add-topic-btn" href="#" data-event-title="{{ event.title }}">{% trans "Create new topic" %}</a></li>
             </ul>
         </div>
+        {% endif %}
     {% endif %}
     {% if show_remove and request.user.is_authenticated %}
         <button type="button"


### PR DESCRIPTION
## Summary
- Hide the Add dropdown on event items when the event already belongs to the current topic

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68bd2bc092708328935f4677af2e8bad