### PR TITLE
feat: add reusable topic context builder

### DIFF
--- a/semanticnews/topics/models.py
+++ b/semanticnews/topics/models.py
@@ -97,6 +97,25 @@ class Topic(models.Model):
         if img:
             return img.thumbnail
 
+    def build_context(self):
+        content_md = f"# {self.title}\n\n"
+
+        events = self.events.all()
+        if events:
+            content_md += "## Events\n\n"
+            for event in events:
+                content_md += f"- {event.title} ({event.date})\n"
+
+        contents = self.contents.all()
+        if contents:
+            content_md += "\n## Contents\n\n"
+            for c in contents:
+                title = c.title or ""
+                text = c.markdown or ""
+                content_md += f"### {title}\n{text}\n\n"
+
+        return content_md
+
     def get_embedding(self):
         if self.embedding is None or len(self.embedding) == 0:
             client = OpenAI()

--- a/semanticnews/topics/utils/recaps/api.py
+++ b/semanticnews/topics/utils/recaps/api.py
@@ -39,21 +39,7 @@ def create_recap(request, payload: TopicRecapCreateRequest):
     except Topic.DoesNotExist:
         raise HttpError(404, "Topic not found")
 
-    content_md = f"# {topic.title}\n\n"
-
-    events = topic.events.all()
-    if events:
-        content_md += "## Events\n\n"
-        for event in events:
-            content_md += f"- {event.title} ({event.date})\n"
-
-    contents = topic.contents.all()
-    if contents:
-        content_md += "\n## Contents\n\n"
-        for c in contents:
-            title = c.title or ""
-            text = c.markdown or ""
-            content_md += f"### {title}\n{text}\n\n"
+    content_md = topic.build_context()
 
     if payload.length == "short":
         length_translated = "brief, concise"


### PR DESCRIPTION
## Summary
- add `build_context` method on `Topic` model to compile events and contents into markdown
- refactor recap creation endpoint to use the model method for context

## Testing
- `python manage.py test` *(fails: connection to PostgreSQL at localhost:5432 refused)*

------
https://chatgpt.com/codex/tasks/task_b_68bd349378388328a96892c7c7e89738