### PR TITLE
Add image generation modal to topic detail

### DIFF
--- a/semanticnews/topics/templates/topics/topics_detail.html
+++ b/semanticnews/topics/templates/topics/topics_detail.html
@@ -82,6 +82,7 @@
 
             <div class="gap-2">
                 {% include "topics/recaps/button.html" %}
+                {% include "topics/images/button.html" %}
                 {% include "topics/mcps/button.html" %}
             </div>
 
@@ -222,6 +223,7 @@
 
 {% include "topics/mcps/modal.html" %}
 {% include "topics/recaps/modal.html" %}
+{% include "topics/images/modal.html" %}
 {% include "topics/create_topic_modal.html" %}
 
 {% endblock %}
@@ -232,5 +234,6 @@
     <script src="{% static 'topics/topic_publish.js' %}"></script>
     {% include "topics/create_topic_js.html" %}
     {% include "topics/recaps/scripts.html" %}
+    {% include "topics/images/scripts.html" %}
     {% include "topics/mcps/scripts.html" %}
 {% endblock %}

--- a/semanticnews/topics/utils/images/static/topics/images/topic_image.js
+++ b/semanticnews/topics/utils/images/static/topics/images/topic_image.js
@@ -1,0 +1,30 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('imageForm');
+  if (form) {
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const submitBtn = form.querySelector('button[type="submit"]');
+      submitBtn.disabled = true;
+      const formData = new FormData(form);
+      const payload = {
+        topic_uuid: formData.get('topic_uuid'),
+        size: formData.get('size'),
+        style: formData.get('style')
+      };
+      try {
+        const res = await fetch('/api/topics/image/create', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        if (!res.ok) throw new Error('Request failed');
+        await res.json();
+        window.location.reload();
+      } catch (err) {
+        console.error(err);
+      } finally {
+        submitBtn.disabled = false;
+      }
+    });
+  }
+});

--- a/semanticnews/topics/utils/images/templates/topics/images/button.html
+++ b/semanticnews/topics/utils/images/templates/topics/images/button.html
@@ -1,0 +1,4 @@
+{% load i18n %}
+<button class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#imageModal"{% if topic.status == 'archived' %} disabled{% endif %}>
+    {% trans "Image" %}
+</button>

--- a/semanticnews/topics/utils/images/templates/topics/images/modal.html
+++ b/semanticnews/topics/utils/images/templates/topics/images/modal.html
@@ -1,0 +1,36 @@
+{% load i18n %}
+<div class="modal fade" id="imageModal" tabindex="-1" aria-labelledby="imageModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form id="imageForm">
+                <div class="modal-header">
+                    <h1 class="modal-title fs-5" id="imageModalLabel">{% trans "Create image" %}</h1>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans 'Close' %}"></button>
+                </div>
+                <div class="modal-body">
+                    <input type="hidden" name="topic_uuid" value="{{ topic.uuid }}">
+                    <div class="mb-3">
+                        <label for="imageSize" class="form-label">{% trans "Size" %}</label>
+                        <select class="form-select" name="size" id="imageSize">
+                            <option value="512x512">{% trans "Small" %}</option>
+                            <option value="1024x1024">{% trans "Medium" %}</option>
+                            <option value="1536x1024" selected>{% trans "Large" %}</option>
+                        </select>
+                    </div>
+                    <div class="mb-3">
+                        <label for="imageStyle" class="form-label">{% trans "Style" %}</label>
+                        <select class="form-select" name="style" id="imageStyle">
+                            <option value="default" selected>{% trans "Default" %}</option>
+                            <option value="photo">{% trans "Photo" %}</option>
+                            <option value="illustration">{% trans "Illustration" %}</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Cancel" %}</button>
+                    <button type="submit" class="btn btn-primary">{% trans "Create" %}</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/semanticnews/topics/utils/images/templates/topics/images/scripts.html
+++ b/semanticnews/topics/utils/images/templates/topics/images/scripts.html
@@ -1,0 +1,2 @@
+{% load static %}
+<script src="{% static 'topics/images/topic_image.js' %}"></script>


### PR DESCRIPTION
## Summary
- add image generation button and modal on topic detail toolbar
- provide JS to submit image creation request

## Testing
- `python manage.py test -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68bd391f717c8328825645a15b7e5a8b