### PR TITLE
Add source domain filter to agenda events

### DIFF
--- a/semanticnews/agenda/static/agenda/category_filter.js
+++ b/semanticnews/agenda/static/agenda/category_filter.js
@@ -1,5 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
   const categoryLinks = document.querySelectorAll('.category-filter');
+  const domainSelect = document.getElementById('domainFilter');
   if (!categoryLinks.length) {
     return;
   }
@@ -21,6 +22,9 @@ document.addEventListener('DOMContentLoaded', () => {
         link.classList.remove('active');
       }
     });
+    if (domainSelect && category) {
+      domainSelect.value = '';
+    }
   }
 
   categoryLinks.forEach(link => {
@@ -35,12 +39,25 @@ document.addEventListener('DOMContentLoaded', () => {
         window.location.hash = category;
         applyFilter(category);
       }
+      if (domainSelect) {
+        domainSelect.value = '';
+      }
     });
   });
 
   window.addEventListener('hashchange', () => {
-    applyFilter(window.location.hash.substring(1));
+    const hash = window.location.hash.substring(1);
+    if (hash.startsWith('domain:')) {
+      applyFilter('');
+    } else {
+      applyFilter(hash);
+    }
   });
 
-  applyFilter(window.location.hash.substring(1));
+  const initial = window.location.hash.substring(1);
+  if (!initial.startsWith('domain:')) {
+    applyFilter(initial);
+  } else {
+    applyFilter('');
+  }
 });

--- a/semanticnews/agenda/static/agenda/domain_filter.js
+++ b/semanticnews/agenda/static/agenda/domain_filter.js
@@ -1,0 +1,51 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const domainSelect = document.getElementById('domainFilter');
+  if (!domainSelect) {
+    return;
+  }
+  const categoryLinks = document.querySelectorAll('.category-filter');
+
+  function applyFilter(domain) {
+    const items = document.querySelectorAll('.event-item');
+    items.forEach(item => {
+      const domains = (item.dataset.domains || '').split(' ').filter(Boolean);
+      if (!domain || domains.includes(domain)) {
+        item.classList.remove('d-none');
+      } else {
+        item.classList.add('d-none');
+      }
+    });
+    if (domain) {
+      categoryLinks.forEach(link => link.classList.remove('active'));
+    }
+  }
+
+  domainSelect.addEventListener('change', () => {
+    const domain = domainSelect.value;
+    if (domain) {
+      window.location.hash = `domain:${domain}`;
+    } else {
+      history.replaceState(null, '', window.location.pathname + window.location.search);
+    }
+    applyFilter(domain);
+  });
+
+  window.addEventListener('hashchange', () => {
+    const hash = window.location.hash.substring(1);
+    if (hash.startsWith('domain:')) {
+      const domain = hash.slice(7);
+      domainSelect.value = domain;
+      applyFilter(domain);
+    } else {
+      domainSelect.value = '';
+      applyFilter('');
+    }
+  });
+
+  const initial = window.location.hash.substring(1);
+  if (initial.startsWith('domain:')) {
+    const domain = initial.slice(7);
+    domainSelect.value = domain;
+    applyFilter(domain);
+  }
+});

--- a/semanticnews/agenda/templates/agenda/event_detail.html
+++ b/semanticnews/agenda/templates/agenda/event_detail.html
@@ -38,6 +38,17 @@
             </div>
             {% endif %}
 
+            {% if domains %}
+            <div class="mb-3">
+                <select id="domainFilter" class="form-select form-select-sm w-auto">
+                    <option value="">{% trans "All domains" %}</option>
+                    {% for domain in domains %}
+                        <option value="{{ domain }}">{{ domain }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            {% endif %}
+
             {% for sim_event in similar_events %}
                 {% include "agenda/event_list_item.html" with event=sim_event %}
             {% empty %}
@@ -83,5 +94,6 @@
     <script src="{% static 'agenda/event_modal.js' %}"></script>
     {% endif %}
     <script src="{% static 'agenda/category_filter.js' %}"></script>
+    <script src="{% static 'agenda/domain_filter.js' %}"></script>
     {% include "topics/create_topic_js.html" %}
 {% endblock %}

--- a/semanticnews/agenda/templates/agenda/event_list.html
+++ b/semanticnews/agenda/templates/agenda/event_list.html
@@ -52,6 +52,17 @@
     </div>
     {% endif %}
 
+    {% if domains %}
+    <div class="mb-3">
+        <select id="domainFilter" class="form-select form-select-sm w-auto">
+            <option value="">{% trans "All domains" %}</option>
+            {% for domain in domains %}
+                <option value="{{ domain }}">{{ domain }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    {% endif %}
+
     {% for event in events %}
         {% include "agenda/event_list_item.html" %}
     {% empty %}
@@ -75,5 +86,6 @@
     {% include "topics/create_topic_js.html" %}
     {% endif %}
     <script src="{% static 'agenda/category_filter.js' %}"></script>
+    <script src="{% static 'agenda/domain_filter.js' %}"></script>
 {% endblock %}
 

--- a/semanticnews/agenda/templates/agenda/event_list_item.html
+++ b/semanticnews/agenda/templates/agenda/event_list_item.html
@@ -1,7 +1,7 @@
 
 {% load i18n %}
 
-<div class="event-item mb-3" data-event-uuid="{{ event.uuid }}" data-categories="{% for category in event.categories.all %}{% if not forloop.first %} {% endif %}{{ category.name|slugify }}{% endfor %}">
+<div class="event-item mb-3" data-event-uuid="{{ event.uuid }}" data-categories="{% for category in event.categories.all %}{% if not forloop.first %} {% endif %}{{ category.name|slugify }}{% endfor %}" data-domains="{% for source in event.sources.all %}{% if not forloop.first %} {% endif %}{{ source.domain }}{% endfor %}">
     <p class="text-secondary small mb-0">
         {{ event.date|date:"M d, Y" }}
         {% for category in event.categories.all %}


### PR DESCRIPTION
## Summary
- show unique source domains in event list and event detail pages
- filter events on the frontend by selected domain
- update category filter to reset when domain filter is used

## Testing
- ⚠️ `python manage.py test` *(database connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68bdb4db30408328877ec7c8fd5b41b4