### PR TITLE
Add configurable site branding settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Site branding
+SITE_TITLE=Semantic.news
+SITE_LOGO=logo.png
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-!.gitignore
 .*
+!.gitignore
+!.env.example
 *.pyc
 media/

--- a/semanticnews/context_processors.py
+++ b/semanticnews/context_processors.py
@@ -1,0 +1,10 @@
+from django.conf import settings
+
+
+def branding(request):
+    """Expose site branding settings to templates."""
+    return {
+        "SITE_TITLE": settings.SITE_TITLE,
+        "SITE_LOGO": settings.SITE_LOGO,
+    }
+

--- a/semanticnews/settings.py
+++ b/semanticnews/settings.py
@@ -23,6 +23,10 @@ HOST = os.getenv('HOST', 'localhost')
 
 ALLOWED_HOSTS = [HOST]
 
+# Site branding
+SITE_TITLE = os.getenv("SITE_TITLE", "Semantic.news")
+SITE_LOGO = os.getenv("SITE_LOGO", "logo.png")
+
 
 # Application definition
 
@@ -71,6 +75,7 @@ TEMPLATES = [
                 'django.template.context_processors.i18n',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'semanticnews.context_processors.branding',
             ],
         },
     },

--- a/semanticnews/templates/base.html
+++ b/semanticnews/templates/base.html
@@ -10,9 +10,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link rel="icon" type="image/x-icon" href="{% static 'logo.png' %}">
+    <link rel="icon" type="image/x-icon" href="{% static SITE_LOGO %}">
 
-    <title>{% block title %}Semantic.news{% endblock %}</title>
+    <title>{% block title %}{{ SITE_TITLE }}{% endblock %}</title>
 
     <!-- Bootstrap CSS -->
     <link href="https://fastly.jsdelivr.net/npm/bootstrap@5.3.5/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -71,7 +71,7 @@
 
                 <li class="nav-item">
                     <a class="nav-link p-0 active" role="button" href="/">
-                        semantic.news
+                        {{ SITE_TITLE }}
                     </a>
                 </li>
 


### PR DESCRIPTION
## Summary
- Add `SITE_TITLE` and `SITE_LOGO` settings sourced from env vars
- Provide `branding` context processor and inject into templates
- Use settings in base template and document in `.env.example`

## Testing
- ⚠️ `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68be5726ffdc8328b3c89a545ef97f8b