### PR TITLE
Refactor recap creation flow

### DIFF
--- a/semanticnews/topics/utils/recaps/static/topics/recaps/topic_recap.js
+++ b/semanticnews/topics/utils/recaps/static/topics/recaps/topic_recap.js
@@ -26,7 +26,31 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   const form = document.getElementById('recapForm');
-  if (form) {
+  const suggestionBtn = document.getElementById('fetchRecapSuggestion');
+  const recapTextarea = document.getElementById('recapText');
+
+  if (suggestionBtn && recapTextarea && form) {
+    suggestionBtn.addEventListener('click', async () => {
+      suggestionBtn.disabled = true;
+      const topicUuid = form.querySelector('input[name="topic_uuid"]').value;
+      try {
+        const res = await fetch('/api/topics/recap/create', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ topic_uuid: topicUuid })
+        });
+        if (!res.ok) throw new Error('Request failed');
+        const data = await res.json();
+        recapTextarea.value = data.recap;
+      } catch (err) {
+        console.error(err);
+      } finally {
+        suggestionBtn.disabled = false;
+      }
+    });
+  }
+
+  if (form && recapTextarea) {
     form.addEventListener('submit', async (e) => {
       e.preventDefault();
       const submitBtn = form.querySelector('button[type="submit"]');
@@ -37,21 +61,14 @@ document.addEventListener('DOMContentLoaded', () => {
         const modal = window.bootstrap.Modal.getInstance(recapModal);
         if (modal) modal.hide();
       }
-      const formData = new FormData(form);
-      const payload = {
-        topic_uuid: formData.get('topic_uuid'),
-        websearch: formData.get('websearch') === 'on',
-        length: formData.get('length'),
-        tone: formData.get('tone'),
-      };
-      const instructions = formData.get('instructions');
-      if (instructions) payload.instructions = instructions;
+      const topicUuid = form.querySelector('input[name="topic_uuid"]').value;
+      const recap = recapTextarea.value;
 
       try {
         const res = await fetch('/api/topics/recap/create', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload)
+          body: JSON.stringify({ topic_uuid: topicUuid, recap })
         });
         if (!res.ok) throw new Error('Request failed');
         await res.json();

--- a/semanticnews/topics/utils/recaps/templates/topics/recaps/modal.html
+++ b/semanticnews/topics/utils/recaps/templates/topics/recaps/modal.html
@@ -1,46 +1,28 @@
 {% load i18n %}
-<div class="modal fade" id="recapModal" tabindex="-1" aria-labelledby="recapModalLabel" aria-hidden="true">
+<div class="modal fade" id="recapModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
-            <form id="recapForm">
-                <div class="modal-header">
-                    <h1 class="modal-title fs-5" id="recapModalLabel">{% trans "Update recap" %}</h1>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans 'Close' %}"></button>
-                </div>
-                <div class="modal-body">
+            <div class="modal-header">
+                <h5 class="modal-title">{% trans "Update recap" %}</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans 'Close' %}"></button>
+            </div>
+            <div class="modal-body">
+                <form id="recapForm">
                     <input type="hidden" name="topic_uuid" value="{{ topic.uuid }}">
-                    <div class="form-check mb-3">
-                        <input class="form-check-input" type="checkbox" name="websearch" id="recapWebsearch">
-                        <label class="form-check-label" for="recapWebsearch">{% trans "Use web search" %}</label>
-                    </div>
                     <div class="mb-3">
-                        <label for="recapLength" class="form-label">{% trans "Length" %}</label>
-                        <select class="form-select" name="length" id="recapLength">
-                            <option value="short">{% trans "Short" %}</option>
-                            <option value="medium" selected>{% trans "Medium" %}</option>
-                            <option value="long">{% trans "Long" %}</option>
-                        </select>
+                        <label for="recapText" class="form-label">{% trans "Recap" %}</label>
+                        <textarea class="form-control" id="recapText" name="recap" rows="8">{% if latest_recap %}{{ latest_recap.recap }}{% endif %}</textarea>
                     </div>
-                    <div class="mb-3">
-                        <label for="recapTone" class="form-label">{% trans "Tone" %}</label>
-                        <select class="form-select" name="tone" id="recapTone">
-                            <option value="neutral" selected>{% trans "Neutral" %}</option>
-                            <option value="journalistic">{% trans "Journalistic" %}</option>
-                            <option value="academic">{% trans "Academic" %}</option>
-                            <option value="friendly">{% trans "Friendly" %}</option>
-                            <option value="sarcastic">{% trans "Sarcastic" %}</option>
-                        </select>
+                    <div class="modal-footer px-0">
+                        <button type="button" class="btn btn-outline-secondary float-start me-auto" id="fetchRecapSuggestion">
+                            <i class="bi bi-stars"></i>
+                            {% trans "Get AI suggestions" %}
+                        </button>
+                        <button type="submit" class="btn btn-primary">{% trans "Update" %}</button>
                     </div>
-                    <div class="mb-3">
-                        <label for="recapInstructions" class="form-label">{% trans "Instructions" %}</label>
-                        <textarea class="form-control" name="instructions" id="recapInstructions" rows="3"></textarea>
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Cancel" %}</button>
-                    <button type="submit" class="btn btn-primary">{% trans "Update" %}</button>
-                </div>
-            </form>
+                </form>
+            </div>
         </div>
     </div>
 </div>
+


### PR DESCRIPTION
## Summary
- Replace recap creation options with a single markdown textarea prefilled with the latest recap
- Add button for AI suggestions and update JS to fetch and save recaps
- Simplify recap API to accept optional text and return suggestions without extra parameters

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68c033499a7c8328a3a8cd931ed5f55e