### PR TITLE
Implement semantic search view

### DIFF
--- a/semanticnews/templates/search_results.html
+++ b/semanticnews/templates/search_results.html
@@ -1,164 +1,28 @@
 {% extends "base.html" %}
-
-{% load static i18n humanize %}
+{% load i18n %}
 
 {% block title %}{% trans "Search" %} &middot; {{ block.super }}{% endblock %}
 
-
 {% block content %}
-
-
-<!-- title section -->
 <div class="d-flex border-bottom mb-3 pb-2">
-
-    <div>
-
-        <h1 class="fs-3">
-
-            {% blocktrans %}Search results for "{{ search_query }}"{% endblocktrans %}
-
-        </h1>
-
-    </div>
-
-
-    <div class="ms-auto mt-auto pb-2">
-        {# Authenticated user #}
-        <button type="button"
-                class="authenticated-only d-none btn btn-outline-primary btn-sm"
-                data-flow="search"
-                data-bs-toggle="modal"
-                data-bs-target="#createTopicModal">
-          {% trans "Create new topic" %}
-        </button>
-
-        {# Anonymous user => login #}
-        <a href="{% url 'login' %}" data-bs-toggle="tooltip" data-bs-title="{% trans "Login to create a topic" %}"
-           class="anonymous-only d-none btn btn-outline-secondary btn-sm">
-            {% trans "Create new topic" %}
-        </a>
-    </div>
-
+    <h1 class="fs-3 mb-0">{% blocktrans %}Search results for "{{ search_query }}"{% endblocktrans %}</h1>
 </div>
-
-
-
-<div class="row">
-
+<div class="row h-100">
     <div class="col-12 col-md-8">
-
-        {% if search_query %}
-
-            <div id="searchResultsList">
-
-                {% for topic in similar_topics %}
-
-                    {% include "topics/topics_list_item.html" with topic=topic %}
-
-                {% endfor %}
-
-{% comment %}
-                <small class="d-flex justify-content-end">
-                    <a href="#"
-                       class="text-info-emphasis text-decoration-none">
-                        {% trans "See more" %}
-                        <i class="bi bi-box-arrow-right ms-1"></i>
-                    </a>
-                </small>
-{% endcomment %}
-
-            </div>
-
-        {% endif %}
-
+        <h2 class="fs-5 mb-2">{% trans "Topics" %}</h2>
+        {% for topic in topics %}
+            {% include "topics/topics_list_item.html" %}
+        {% empty %}
+            <p class="text-secondary small">{% trans "No topics found" %}</p>
+        {% endfor %}
     </div>
-
-
     <div class="col-12 col-md-4">
-
-        {% if recommended_keywords %}
-
-            <div class="card">
-
-                <div class="card-body">
-
-                    <h6 class="card-title fs-5">{% trans "Related keywords" %}</h6>
-
-                    <div class="card-text d-flex flex-wrap">
-                        {% for keyword in recommended_keywords %}
-                            <a class="text-info-emphasis text-decoration-none w-50" href="{% url 'topics_detail' slug=keyword.slug %}">
-                                {{ keyword.get_name_i18n }}
-                            </a>
-                            {% if not forloop.last %}<br>{% endif %}
-                        {% endfor %}
-                    </div>
-
-                </div>
-
-            </div>
-
-        {% endif %}
-
-        <div class="card mt-3">
-
-            <div class="card-body">
-
-                <h6 class="card-title fs-5">{% trans "Recommended content" %}</h6>
-
-                {% if recommended_articles %}
-
-                    {% for recommended_article in recommended_articles %}
-
-                          {% include "topics/topics_list_article_item.html" %}
-
-                    {% endfor %}
-
-                {% endif %}
-
-                {% if recommended_rss_items %}
-
-                    {% for rss_item in recommended_rss_items %}
-
-                        {% include "topics/topics_list_rssitem_item.html" %}
-
-                    {% endfor %}
-
-                {% endif %}
-
-                {% if recommended_videos %}
-
-                    {% for chunk in recommended_videos %}
-
-                        {% include "topics/topics_list_video_item.html" %}
-
-                    {% endfor %}
-
-                {% endif %}
-
-                {% if not recommended_articles and not recommended_rss_items and not recommended_videos %}
-
-                    <p class="small">{% trans "No content found." %}</p>
-
-                {% endif %}
-
-            </div>
-
-        </div>
-
+        <h2 class="fs-5 mb-2">{% trans "Agenda" %}</h2>
+        {% for event in events %}
+            {% include "agenda/event_list_item.html" %}
+        {% empty %}
+            <p class="text-secondary small">{% trans "No events found" %}</p>
+        {% endfor %}
     </div>
-
 </div>
-
-
-{% include "topics/create_topic_modal.html" %}
-
-{% endblock %}
-
-
-{% block extra_js %}
-
-{% include "bookmarks_js.html" %}
-
-{% include "topics/create_topic_js.html" %}
-
 {% endblock %}

--- a/semanticnews/tests.py
+++ b/semanticnews/tests.py
@@ -1,0 +1,48 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+from django.urls import reverse
+
+from semanticnews.topics.models import Topic
+from semanticnews.agenda.models import Event
+
+
+class SearchViewTests(TestCase):
+    @patch("semanticnews.views.OpenAI")
+    @patch(
+        "semanticnews.topics.models.Topic.get_embedding",
+        side_effect=[[0.0] * 1536, [1.0] * 1536],
+    )
+    def test_search_returns_similar_topics_and_events(
+        self, mock_topic_embedding, mock_openai
+    ):
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+        mock_client.embeddings.create.return_value = MagicMock(
+            data=[MagicMock(embedding=[0.0] * 1536)]
+        )
+
+        topic1 = Topic.objects.create(title="Topic One", status="published")
+        topic2 = Topic.objects.create(title="Topic Two", status="published")
+
+        Event.objects.create(
+            title="Event One",
+            date="2024-01-01",
+            status="published",
+            embedding=[0.0] * 1536,
+        )
+        Event.objects.create(
+            title="Event Two",
+            date="2024-01-02",
+            status="published",
+            embedding=[1.0] * 1536,
+        )
+
+        response = self.client.get(reverse("search_results"), {"q": "query"})
+        self.assertEqual(response.status_code, 200)
+        topics = list(response.context["topics"])
+        events = list(response.context["events"])
+        self.assertEqual(len(topics), 2)
+        self.assertEqual(len(events), 2)
+        self.assertEqual(topics[0], topic1)
+        self.assertEqual(events[0].title, "Event One")

--- a/semanticnews/urls.py
+++ b/semanticnews/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
 
 urlpatterns += i18n_patterns(
     path('', core_views.home, name='home'),
+    path('search/', core_views.search_results, name='search_results'),
 
     re_path(
         r'^(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})/(?P<slug>[-\w]+)/$',

--- a/semanticnews/views.py
+++ b/semanticnews/views.py
@@ -1,6 +1,9 @@
 from django.shortcuts import render
+from pgvector.django import L2Distance
+
 from .agenda.models import Event
 from .topics.models import Topic
+from .openai import OpenAI
 
 
 def home(request):
@@ -12,3 +15,46 @@ def home(request):
     if request.user.is_authenticated:
         context['user_topics'] = Topic.objects.filter(created_by=request.user)
     return render(request, 'home.html', context)
+
+
+def search_results(request):
+    """Search for topics and events similar to the query string."""
+
+    query = request.GET.get("q", "").strip()
+    topics = Topic.objects.none()
+    events = Event.objects.none()
+
+    if query:
+        client = OpenAI()
+        embedding = (
+            client.embeddings.create(
+                model="text-embedding-3-small",
+                input=query,
+            )
+            .data[0]
+            .embedding
+        )
+
+        topics = (
+            Topic.objects.filter(status="published")
+            .exclude(embedding__isnull=True)
+            .annotate(distance=L2Distance("embedding", embedding))
+            .order_by("distance")[:5]
+        )
+
+        events = (
+            Event.objects.filter(status="published")
+            .exclude(embedding__isnull=True)
+            .annotate(distance=L2Distance("embedding", embedding))
+            .order_by("distance")[:5]
+        )
+
+    context = {
+        "search_query": query,
+        "topics": topics,
+        "events": events,
+    }
+    if request.user.is_authenticated:
+        context["user_topics"] = Topic.objects.filter(created_by=request.user)
+
+    return render(request, "search_results.html", context)


### PR DESCRIPTION
## Summary
- Add search endpoint using embeddings to find similar topics and agenda events
- Route search URL and provide search results template mirroring homepage layout
- Cover search workflow with a dedicated test

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68c040198a0c83289679f15e0aeeb63e