### PR TITLE
Add narratives modal to topic toolbar

### DIFF
--- a/semanticnews/topics/templates/topics/topics_detail.html
+++ b/semanticnews/topics/templates/topics/topics_detail.html
@@ -82,6 +82,7 @@
 
             <div class="gap-2">
                 {% include "topics/recaps/button.html" %}
+                {% include "topics/narratives/button.html" %}
                 {% include "topics/images/button.html" %}
                 {% include "topics/mcps/button.html" %}
             </div>
@@ -227,6 +228,7 @@
 
 {% include "topics/mcps/modal.html" %}
 {% include "topics/recaps/modal.html" %}
+{% include "topics/narratives/modal.html" %}
 {% include "topics/images/modal.html" %}
 {% include "topics/create_topic_modal.html" %}
 
@@ -238,6 +240,7 @@
     <script src="{% static 'topics/topic_publish.js' %}"></script>
     {% include "topics/create_topic_js.html" %}
     {% include "topics/recaps/scripts.html" %}
+    {% include "topics/narratives/scripts.html" %}
     {% include "topics/images/scripts.html" %}
     {% include "topics/mcps/scripts.html" %}
 {% endblock %}

--- a/semanticnews/topics/utils/narratives/static/topics/narratives/topic_narrative.js
+++ b/semanticnews/topics/utils/narratives/static/topics/narratives/topic_narrative.js
@@ -1,0 +1,84 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const narrativeBtn = document.getElementById('narrativeButton');
+  const narrativeSpinner = document.getElementById('narrativeSpinner');
+  const showLoading = () => {
+    if (narrativeBtn && narrativeSpinner) {
+      narrativeBtn.disabled = true;
+      narrativeSpinner.classList.remove('d-none');
+    }
+  };
+  const hideLoading = () => {
+    if (narrativeBtn && narrativeSpinner) {
+      narrativeBtn.disabled = false;
+      narrativeSpinner.classList.add('d-none');
+    }
+  };
+
+  if (narrativeBtn) {
+    const status = narrativeBtn.dataset.narrativeStatus;
+    const created = narrativeBtn.dataset.narrativeCreated;
+    if (status === 'in_progress' && created) {
+      const createdDate = new Date(created);
+      if (Date.now() - createdDate.getTime() < 2 * 60 * 1000) {
+        showLoading();
+      }
+    }
+  }
+
+  const form = document.getElementById('narrativeForm');
+  const suggestionBtn = document.getElementById('fetchNarrativeSuggestion');
+  const narrativeTextarea = document.getElementById('narrativeText');
+
+  if (suggestionBtn && narrativeTextarea && form) {
+    suggestionBtn.addEventListener('click', async () => {
+      suggestionBtn.disabled = true;
+      const topicUuid = form.querySelector('input[name="topic_uuid"]').value;
+      try {
+        const res = await fetch('/api/topics/narrative/create', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ topic_uuid: topicUuid })
+        });
+        if (!res.ok) throw new Error('Request failed');
+        const data = await res.json();
+        narrativeTextarea.value = data.narrative;
+      } catch (err) {
+        console.error(err);
+      } finally {
+        suggestionBtn.disabled = false;
+      }
+    });
+  }
+
+  if (form && narrativeTextarea) {
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const submitBtn = form.querySelector('button[type="submit"]');
+      submitBtn.disabled = true;
+      showLoading();
+      const narrativeModal = document.getElementById('narrativeModal');
+      if (narrativeModal && window.bootstrap) {
+        const modal = window.bootstrap.Modal.getInstance(narrativeModal);
+        if (modal) modal.hide();
+      }
+      const topicUuid = form.querySelector('input[name="topic_uuid"]').value;
+      const narrative = narrativeTextarea.value;
+
+      try {
+        const res = await fetch('/api/topics/narrative/create', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ topic_uuid: topicUuid, narrative })
+        });
+        if (!res.ok) throw new Error('Request failed');
+        await res.json();
+        window.location.reload();
+      } catch (err) {
+        console.error(err);
+
+        submitBtn.disabled = false;
+        hideLoading();
+      }
+    });
+  }
+});

--- a/semanticnews/topics/utils/narratives/templates/topics/narratives/button.html
+++ b/semanticnews/topics/utils/narratives/templates/topics/narratives/button.html
@@ -1,0 +1,11 @@
+{% load i18n %}
+<button
+    id="narrativeButton"
+    class="btn btn-outline-secondary btn-sm"
+    data-bs-toggle="modal"
+    data-bs-target="#narrativeModal"
+    data-narrative-status="{% if current_narrative %}{{ current_narrative.status }}{% endif %}"
+    data-narrative-created="{% if current_narrative %}{{ current_narrative.created_at|date:'c' }}{% endif %}"{% if topic.status == 'archived' %} disabled{% endif %}>
+    <span id="narrativeSpinner" class="spinner-border spinner-border-sm me-1 d-none" role="status" aria-hidden="true"></span>
+    {% trans "Narrative" %}
+</button>

--- a/semanticnews/topics/utils/narratives/templates/topics/narratives/modal.html
+++ b/semanticnews/topics/utils/narratives/templates/topics/narratives/modal.html
@@ -1,0 +1,27 @@
+{% load i18n %}
+<div class="modal fade" id="narrativeModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">{% trans "Update narrative" %}</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans 'Close' %}"></button>
+            </div>
+            <div class="modal-body">
+                <form id="narrativeForm">
+                    <input type="hidden" name="topic_uuid" value="{{ topic.uuid }}">
+                    <div class="mb-3">
+                        <label for="narrativeText" class="form-label">{% trans "Narrative" %}</label>
+                        <textarea class="form-control" id="narrativeText" name="narrative" rows="8">{% if latest_narrative %}{{ latest_narrative.narrative }}{% endif %}</textarea>
+                    </div>
+                    <div class="modal-footer px-0">
+                        <button type="button" class="btn btn-outline-secondary float-start me-auto" id="fetchNarrativeSuggestion">
+                            <i class="bi bi-stars"></i>
+                            {% trans "Get AI suggestions" %}
+                        </button>
+                        <button type="submit" class="btn btn-primary">{% trans "Update" %}</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/semanticnews/topics/utils/narratives/templates/topics/narratives/scripts.html
+++ b/semanticnews/topics/utils/narratives/templates/topics/narratives/scripts.html
@@ -1,0 +1,2 @@
+{% load static %}
+<script src="{% static 'topics/narratives/topic_narrative.js' %}"></script>


### PR DESCRIPTION
## Summary
- add Narrative button and modal dialog to topic toolbar
- wire up JS to fetch AI narrative suggestions and save narratives

## Testing
- `python3 manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68c04b0ac8ec8328a5bf691a3cc8e066