### PR TITLE
Show topic thumbnail and recap in list items

### DIFF
--- a/semanticnews/tests.py
+++ b/semanticnews/tests.py
@@ -1,10 +1,15 @@
 from unittest.mock import MagicMock, patch
+import tempfile
+import shutil
 
 from django.test import TestCase
 from django.urls import reverse
+from django.core.files.uploadedfile import SimpleUploadedFile
 
 from semanticnews.topics.models import Topic
 from semanticnews.agenda.models import Event
+from semanticnews.topics.utils.images.models import TopicImage
+from semanticnews.topics.utils.recaps.models import TopicRecap
 
 
 class SearchViewTests(TestCase):
@@ -46,3 +51,31 @@ class SearchViewTests(TestCase):
         self.assertEqual(len(events), 2)
         self.assertEqual(topics[0], topic1)
         self.assertEqual(events[0].title, "Event One")
+
+
+class HomeViewTopicListItemTests(TestCase):
+    @patch("semanticnews.topics.models.Topic.get_embedding", return_value=[0.0] * 1536)
+    def test_home_displays_thumbnail_and_recap(self, mock_embedding):
+        tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmpdir)
+        override = self.settings(MEDIA_ROOT=tmpdir)
+        override.enable()
+        self.addCleanup(override.disable)
+
+        topic = Topic.objects.create(title="Topic", status="published")
+
+        image_data = (
+            b"GIF89a\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00"
+            b"\xff\xff\xff!\xf9\x04\x01\x00\x00\x00\x00,\x00"
+            b"\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02L\x01\x00;"
+        )
+        image_file = SimpleUploadedFile("image.gif", image_data, content_type="image/gif")
+        thumb_file = SimpleUploadedFile("thumb.gif", image_data, content_type="image/gif")
+        TopicImage.objects.create(topic=topic, image=image_file, thumbnail=thumb_file)
+
+        TopicRecap.objects.create(topic=topic, recap="My recap", status="finished")
+
+        response = self.client.get(reverse("home"))
+
+        self.assertContains(response, "My recap")
+        self.assertContains(response, topic.thumbnail.url)

--- a/semanticnews/topics/templates/topics/topics_list_item.html
+++ b/semanticnews/topics/templates/topics/topics_list_item.html
@@ -45,7 +45,15 @@
 
         <a href="{{ topic.get_absolute_url }}" class="stretched-link"></a>
 
-        {# Add topics recap, etc. here #}
+        {% if topic.thumbnail %}
+            <img src="{{ topic.thumbnail.url }}" alt="{{ topic.title }}" class="img-fluid rounded mb-2">
+        {% endif %}
+
+        {% with topic.recaps.last as latest_recap %}
+            {% if latest_recap %}
+                <div class="small text-body">{{ latest_recap.recap|markdownify }}</div>
+            {% endif %}
+        {% endwith %}
 
     </div>
 


### PR DESCRIPTION
## Summary
- Display topic thumbnail and most recent recap in topic list items
- Cover list rendering with a new home view test

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68c06a9db314832891c55d41d5acc8d3