### PR TITLE
Add narrative card to topic detail page

### DIFF
--- a/semanticnews/topics/templates/topics/topics_detail.html
+++ b/semanticnews/topics/templates/topics/topics_detail.html
@@ -120,6 +120,8 @@
 
         {% include "topics/recaps/card.html" %}
 
+        {% include "topics/narratives/card.html" %}
+
     </div>
 
 

--- a/semanticnews/topics/utils/narratives/templates/topics/narratives/card.html
+++ b/semanticnews/topics/utils/narratives/templates/topics/narratives/card.html
@@ -1,0 +1,9 @@
+{% load i18n markdown_extras %}
+<div class="card my-3" id="topicNarrativeContainer"{% if not latest_narrative %} style="display: none;"{% endif %}>
+    <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center mb-2">
+            <h6 class="fs-5 mb-0">{% trans "Narrative" %}</h6>
+        </div>
+        <div id="topicNarrativeText">{% if latest_narrative %}{{ latest_narrative.narrative|markdownify }}{% endif %}</div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- Display narratives using a new card on topic detail pages
- Include narrative card template powered by Markdown rendering

## Testing
- `pytest` *(fails: Requested setting DATABASES, but settings are not configured)*
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_b_68c07606665c8328a645ffa994cae5c4