### PR TITLE
Add topic relations modal with suggestions

### DIFF
--- a/semanticnews/topics/templates/topics/topics_detail.html
+++ b/semanticnews/topics/templates/topics/topics_detail.html
@@ -84,6 +84,7 @@
                 {% include "topics/recaps/button.html" %}
                 {% include "topics/narratives/button.html" %}
                 {% include "topics/images/button.html" %}
+                {% include "topics/relations/button.html" %}
                 {% include "topics/mcps/button.html" %}
             </div>
 
@@ -232,6 +233,7 @@
 {% include "topics/recaps/modal.html" %}
 {% include "topics/narratives/modal.html" %}
 {% include "topics/images/modal.html" %}
+{% include "topics/relations/modal.html" %}
 {% include "topics/create_topic_modal.html" %}
 
 {% endblock %}
@@ -244,5 +246,6 @@
     {% include "topics/recaps/scripts.html" %}
     {% include "topics/narratives/scripts.html" %}
     {% include "topics/images/scripts.html" %}
+    {% include "topics/relations/scripts.html" %}
     {% include "topics/mcps/scripts.html" %}
 {% endblock %}

--- a/semanticnews/topics/utils/relations/static/topics/relations/topic_relation.js
+++ b/semanticnews/topics/utils/relations/static/topics/relations/topic_relation.js
@@ -1,0 +1,89 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const relationBtn = document.getElementById('relationButton');
+  const relationSpinner = document.getElementById('relationSpinner');
+  const showLoading = () => {
+    if (relationBtn && relationSpinner) {
+      relationBtn.disabled = true;
+      relationSpinner.classList.remove('d-none');
+    }
+  };
+  const hideLoading = () => {
+    if (relationBtn && relationSpinner) {
+      relationBtn.disabled = false;
+      relationSpinner.classList.add('d-none');
+    }
+  };
+
+  if (relationBtn) {
+    const status = relationBtn.dataset.relationStatus;
+    const created = relationBtn.dataset.relationCreated;
+    if (status === 'in_progress' && created) {
+      const createdDate = new Date(created);
+      if (Date.now() - createdDate.getTime() < 2 * 60 * 1000) {
+        showLoading();
+      }
+    }
+  }
+
+  const form = document.getElementById('relationForm');
+  const suggestionBtn = document.getElementById('fetchRelationSuggestion');
+  const relationTextarea = document.getElementById('relationText');
+
+  if (suggestionBtn && relationTextarea && form) {
+    suggestionBtn.addEventListener('click', async () => {
+      suggestionBtn.disabled = true;
+      const topicUuid = form.querySelector('input[name="topic_uuid"]').value;
+      try {
+        const res = await fetch('/api/topics/relation/extract', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ topic_uuid: topicUuid })
+        });
+        if (!res.ok) throw new Error('Request failed');
+        const data = await res.json();
+        relationTextarea.value = JSON.stringify(data.relations, null, 2);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        suggestionBtn.disabled = false;
+      }
+    });
+  }
+
+  if (form && relationTextarea) {
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      let relations;
+      try {
+        relations = JSON.parse(relationTextarea.value || '[]');
+      } catch (err) {
+        alert('Invalid JSON');
+        return;
+      }
+      const submitBtn = form.querySelector('button[type="submit"]');
+      submitBtn.disabled = true;
+      showLoading();
+      const relationModal = document.getElementById('relationModal');
+      if (relationModal && window.bootstrap) {
+        const modal = window.bootstrap.Modal.getInstance(relationModal);
+        if (modal) modal.hide();
+      }
+      const topicUuid = form.querySelector('input[name="topic_uuid"]').value;
+      try {
+        const res = await fetch('/api/topics/relation/extract', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ topic_uuid: topicUuid, relations })
+        });
+        if (!res.ok) throw new Error('Request failed');
+        await res.json();
+        window.location.reload();
+      } catch (err) {
+        console.error(err);
+        submitBtn.disabled = false;
+        hideLoading();
+      }
+    });
+  }
+});
+

--- a/semanticnews/topics/utils/relations/templates/topics/relations/button.html
+++ b/semanticnews/topics/utils/relations/templates/topics/relations/button.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+<button
+    id="relationButton"
+    class="btn btn-outline-secondary btn-sm"
+    data-bs-toggle="modal"
+    data-bs-target="#relationModal"
+    data-relation-status="{% if current_relation %}{{ current_relation.status }}{% endif %}"
+    data-relation-created="{% if current_relation %}{{ current_relation.created_at|date:'c' }}{% endif %}"{% if topic.status == 'archived' %} disabled{% endif %}>
+    <span id="relationSpinner" class="spinner-border spinner-border-sm me-1 d-none" role="status" aria-hidden="true"></span>
+    {% trans "Relations" %}
+</button>
+

--- a/semanticnews/topics/utils/relations/templates/topics/relations/modal.html
+++ b/semanticnews/topics/utils/relations/templates/topics/relations/modal.html
@@ -1,0 +1,28 @@
+{% load i18n %}
+<div class="modal fade" id="relationModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">{% trans "Entity relations" %}</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans 'Close' %}"></button>
+            </div>
+            <div class="modal-body">
+                <form id="relationForm">
+                    <input type="hidden" name="topic_uuid" value="{{ topic.uuid }}">
+                    <div class="mb-3">
+                        <label for="relationText" class="form-label">{% trans "Relations" %}</label>
+                        <textarea class="form-control" id="relationText" name="relations" rows="8">{{ relations_json }}</textarea>
+                    </div>
+                    <div class="modal-footer px-0">
+                        <button type="button" class="btn btn-outline-secondary float-start me-auto" id="fetchRelationSuggestion">
+                            <i class="bi bi-stars"></i>
+                            {% trans "Get suggestions" %}
+                        </button>
+                        <button type="submit" class="btn btn-primary">{% trans "Create" %}</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+

--- a/semanticnews/topics/utils/relations/templates/topics/relations/scripts.html
+++ b/semanticnews/topics/utils/relations/templates/topics/relations/scripts.html
@@ -1,0 +1,3 @@
+{% load static %}
+<script src="{% static 'topics/relations/topic_relation.js' %}"></script>
+


### PR DESCRIPTION
## Summary
- add toolbar button and modal to manage topic entity relations
- allow fetching AI suggestions and submitting relation JSON
- load existing relations into modal via view updates

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_b_68c1030f416c8328ad7088b6add10105