### PR TITLE
feat: add topic relation graph card

### DIFF
--- a/semanticnews/topics/templates/topics/topics_detail.html
+++ b/semanticnews/topics/templates/topics/topics_detail.html
@@ -123,6 +123,8 @@
 
         {% include "topics/narratives/card.html" %}
 
+        {% include "topics/relations/card.html" %}
+
     </div>
 
 

--- a/semanticnews/topics/utils/relations/static/topics/relations/topic_relation_graph.js
+++ b/semanticnews/topics/utils/relations/static/topics/relations/topic_relation_graph.js
@@ -1,0 +1,26 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('topicRelationGraph');
+  if (!container) return;
+  let relations = [];
+  try {
+    relations = JSON.parse(container.dataset.relations || '[]');
+  } catch (e) {
+    relations = [];
+  }
+  if (relations.length === 0) {
+    container.innerHTML = '<p class="text-secondary small mb-0">No relations</p>';
+    return;
+  }
+  const nodes = new vis.DataSet();
+  const edges = new vis.DataSet();
+  relations.forEach(r => {
+    if (!nodes.get(r.source)) {
+      nodes.add({ id: r.source, label: r.source });
+    }
+    if (!nodes.get(r.target)) {
+      nodes.add({ id: r.target, label: r.target });
+    }
+    edges.add({ from: r.source, to: r.target, label: r.relation, arrows: 'to' });
+  });
+  new vis.Network(container, { nodes, edges }, {});
+});

--- a/semanticnews/topics/utils/relations/templates/topics/relations/card.html
+++ b/semanticnews/topics/utils/relations/templates/topics/relations/card.html
@@ -1,0 +1,9 @@
+{% load i18n %}
+<div class="card my-3" id="topicRelationContainer"{% if not latest_relation %} style="display: none;"{% endif %}>
+    <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center mb-2">
+            <h6 class="fs-5 mb-0">{% trans "Relations" %}</h6>
+        </div>
+        <div id="topicRelationGraph" data-relations='{{ relations_json|escapejs }}' style="height: 400px;"></div>
+    </div>
+</div>

--- a/semanticnews/topics/utils/relations/templates/topics/relations/scripts.html
+++ b/semanticnews/topics/utils/relations/templates/topics/relations/scripts.html
@@ -1,3 +1,5 @@
 {% load static %}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/vis-network@9.1.2/dist/vis-network.min.css" />
+<script src="https://cdn.jsdelivr.net/npm/vis-network@9.1.2/dist/vis-network.min.js"></script>
 <script src="{% static 'topics/relations/topic_relation.js' %}"></script>
-
+<script src="{% static 'topics/relations/topic_relation_graph.js' %}"></script>


### PR DESCRIPTION
## Summary
- render topic entity relations as a network graph card on topic detail
- load vis-network library and graph renderer script

## Testing
- `python manage.py test` *(fails: type "vector" does not exist)*

------
https://chatgpt.com/codex/tasks/task_b_68c10a6d03008328a988e486d175494d