### PR TITLE
Display all topic data tables with tabs

### DIFF
--- a/semanticnews/topics/utils/data/templates/topics/data/card.html
+++ b/semanticnews/topics/utils/data/templates/topics/data/card.html
@@ -1,30 +1,48 @@
 {% load i18n %}
-<div class="card my-3" id="topicDataContainer"{% if not latest_data %} style="display: none;"{% endif %}>
+<div class="card my-3" id="topicDataContainer"{% if not datas %} style="display: none;"{% endif %}>
     <div class="card-body">
         <div class="d-flex justify-content-between align-items-center mb-2">
             <h6 class="fs-5 mb-0">{% trans "Data" %}</h6>
         </div>
-        {% if latest_data %}
-        <div class="table-responsive">
-            <table class="table table-sm">
-                <thead>
-                    <tr>
-                        {% for header in latest_data.data.headers %}
-                            <th>{{ header }}</th>
-                        {% endfor %}
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for row in latest_data.data.rows %}
-                        <tr>
-                            {% for cell in row %}
-                                <td>{{ cell }}</td>
+        {% if datas %}
+        <ul class="nav nav-tabs mb-3" id="topicDataTabs" role="tablist">
+            {% for data in datas %}
+            <li class="nav-item" role="presentation">
+                <button class="nav-link {% if forloop.first %}active{% endif %}" id="data-tab-{{ forloop.counter }}"
+                        data-bs-toggle="tab" data-bs-target="#data-pane-{{ forloop.counter }}" type="button"
+                        role="tab" {% if forloop.first %}aria-selected="true"{% else %}aria-selected="false"{% endif %}>
+                    {{ data.created_at|date:"Y-m-d" }}
+                </button>
+            </li>
+            {% endfor %}
+        </ul>
+        <div class="tab-content" id="topicDataTabsContent">
+            {% for data in datas %}
+            <div class="tab-pane fade {% if forloop.first %}show active{% endif %}" id="data-pane-{{ forloop.counter }}"
+                 role="tabpanel" aria-labelledby="data-tab-{{ forloop.counter }}">
+                <div class="table-responsive">
+                    <table class="table table-sm">
+                        <thead>
+                            <tr>
+                                {% for header in data.data.headers %}
+                                    <th>{{ header }}</th>
+                                {% endfor %}
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for row in data.data.rows %}
+                                <tr>
+                                    {% for cell in row %}
+                                        <td>{{ cell }}</td>
+                                    {% endfor %}
+                                </tr>
                             {% endfor %}
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-            <p class="small text-muted">{% trans "Source" %}: <a href="{{ latest_data.url }}" target="_blank">{{ latest_data.url }}</a></p>
+                        </tbody>
+                    </table>
+                    <p class="small text-muted">{% trans "Source" %}: <a href="{{ data.url }}" target="_blank">{{ data.url }}</a></p>
+                </div>
+            </div>
+            {% endfor %}
         </div>
         {% endif %}
     </div>

--- a/semanticnews/topics/views.py
+++ b/semanticnews/topics/views.py
@@ -38,6 +38,7 @@ def topics_detail(request, slug, username):
         .first()
     )
     latest_data = topic.datas.order_by("-created_at").first()
+    datas = topic.datas.order_by("-created_at")
     if latest_relation:
         relations_json = json.dumps(
             latest_relation.relations, separators=(",", ":")
@@ -72,6 +73,7 @@ def topics_detail(request, slug, username):
         "latest_narrative": latest_narrative,
         "mcp_servers": mcp_servers,
         "latest_data": latest_data,
+        "datas": datas,
     }
     if request.user.is_authenticated:
         context["user_topics"] = Topic.objects.filter(created_by=request.user).exclude(uuid=topic.uuid)


### PR DESCRIPTION
## Summary
- Add view context to expose all TopicData entries
- Render all data tables under navigation tabs in topic data card

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68c13187c5f0832899eea41d9a928b66