### PR TITLE
Allow custom insights for data visualizations

### DIFF
--- a/semanticnews/topics/utils/data/templates/topics/data/visualize_modal.html
+++ b/semanticnews/topics/utils/data/templates/topics/data/visualize_modal.html
@@ -18,9 +18,14 @@
                         {% empty %}
                         <p class="text-secondary mb-0">{% trans "No insights available" %}</p>
                         {% endfor %}
+                        <div class="form-check mt-2">
+                            <input class="form-check-input" type="radio" name="insight_id" id="visualizeInsightOther" value="other"{% if not data_insights %} checked{% endif %}>
+                            <label class="form-check-label" for="visualizeInsightOther">{% trans "Other" %}</label>
+                        </div>
+                        <input type="text" class="form-control mt-2 d-none" id="visualizeInsightOtherText" placeholder="{% trans 'Enter your insight' %}">
                     </div>
                     <div class="modal-footer px-0">
-                        <button type="button" class="btn btn-outline-secondary float-start me-auto" id="visualizeDataBtn"{% if not data_insights %} disabled{% endif %}>{% trans "Visualize" %}</button>
+                        <button type="button" class="btn btn-outline-secondary float-start me-auto" id="visualizeDataBtn">{% trans "Visualize" %}</button>
                     </div>
                 </form>
             </div>


### PR DESCRIPTION
## Summary
- add an "Other" option with free text input to the Visualize Data modal
- support custom insight text in visualization request API and UI
- test custom insight visualization flow

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68c26ed4808483288e46b0e7c9cae7ba