### PR TITLE
Add chart type selection to data visualization modal

### DIFF
--- a/semanticnews/topics/utils/data/static/topics/data/topic_data.js
+++ b/semanticnews/topics/utils/data/static/topics/data/topic_data.js
@@ -12,6 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const visualizeBtn = document.getElementById('visualizeDataBtn');
   const visualizeForm = document.getElementById('dataVisualizeForm');
   const visualizeOtherInput = document.getElementById('visualizeInsightOtherText');
+  const chartTypeSelect = document.getElementById('visualizeChartType');
   let fetchedData = null;
 
   if (fetchBtn && urlInput) {
@@ -168,6 +169,10 @@ document.addEventListener('DOMContentLoaded', () => {
       } else {
         const insightId = parseInt(value);
         body = { topic_uuid: topicUuid, insight_id: insightId };
+      }
+      const chartType = chartTypeSelect ? chartTypeSelect.value : '';
+      if (chartType) {
+        body.chart_type = chartType;
       }
       try {
         const res = await fetch('/api/topics/data/visualize', {

--- a/semanticnews/topics/utils/data/templates/topics/data/visualize_modal.html
+++ b/semanticnews/topics/utils/data/templates/topics/data/visualize_modal.html
@@ -24,6 +24,15 @@
                         </div>
                         <input type="text" class="form-control mt-2 d-none" id="visualizeInsightOtherText" placeholder="{% trans 'Enter your insight' %}">
                     </div>
+                    <div class="mb-3">
+                        <label for="visualizeChartType" class="form-label">{% trans "Chart type" %}</label>
+                        <select class="form-select" id="visualizeChartType" name="chart_type">
+                            <option value="">{% trans "Let AI decide" %}</option>
+                            <option value="bar">{% trans "Bar" %}</option>
+                            <option value="line">{% trans "Line" %}</option>
+                            <option value="pie">{% trans "Pie" %}</option>
+                        </select>
+                    </div>
                     <div class="modal-footer px-0">
                         <button type="button" class="btn btn-outline-secondary float-start me-auto" id="visualizeDataBtn">{% trans "Visualize" %}</button>
                     </div>


### PR DESCRIPTION
## Summary
- allow selecting chart type when visualizing topic data
- send selected chart type to visualization API and tests
- expose chart type selection in visualization dialog

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68c27235e2988328b3e5389c81aa8671