### PR TITLE
feat: route event creation through timeline tool

### DIFF
--- a/semanticnews/agenda/templates/agenda/event_detail.html
+++ b/semanticnews/agenda/templates/agenda/event_detail.html
@@ -23,11 +23,6 @@
 
             <div class="d-flex justify-content-between align-items-center mb-2">
                 <h2 class="fs-5 mb-0">{% trans "Timeline" %}</h2>
-                {% if user.is_authenticated %}
-                <button id="suggestEventsBtn" data-event-title="{{ event.title }}" class="btn btn-sm btn-outline-secondary" title="{% trans 'Add events' %}">
-                    <i class="bi bi-plus-lg"></i>
-                </button>
-                {% endif %}
             </div>
 
             {% if categories or domains %}
@@ -85,18 +80,11 @@
 </div>
 
 {% include "topics/create_topic_modal.html" %}
-{% if user.is_authenticated %}
-{% include "agenda/event_modal.html" %}
-{% endif %}
 
 {% endblock %}
 
 {% block extra_js %}
     {{ block.super }}
-    {% if user.is_authenticated %}
-    {{ exclude_events|json_script:"exclude-events" }}
-    <script src="{% static 'agenda/event_modal.js' %}"></script>
-    {% endif %}
     <script src="{% static 'agenda/category_filter.js' %}"></script>
     <script src="{% static 'agenda/domain_filter.js' %}"></script>
     {% include "topics/create_topic_js.html" %}

--- a/semanticnews/agenda/templates/agenda/event_list.html
+++ b/semanticnews/agenda/templates/agenda/event_list.html
@@ -36,11 +36,6 @@
                     <i class="bi bi-chevron-right"></i>
                 </a>
             </div>
-            {% if user.is_authenticated %}
-            <button id="addEventBtn" class="btn btn-sm btn-outline-secondary" title="{% trans 'Add event' %}">
-                <i class="bi bi-plus-lg"></i>
-            </button>
-            {% endif %}
         </div>
     </div>
 
@@ -76,7 +71,6 @@
 </div>
 
 {% if user.is_authenticated %}
-{% include "agenda/event_modal.html" %}
 {% include "topics/create_topic_modal.html" %}
 {% endif %}
 
@@ -85,8 +79,6 @@
 {% block extra_js %}
     {{ block.super }}
     {% if user.is_authenticated %}
-    {{ exclude_events|json_script:"exclude-events" }}
-    <script src="{% static 'agenda/event_modal.js' %}"></script>
     {% include "topics/create_topic_js.html" %}
     {% endif %}
     <script src="{% static 'agenda/category_filter.js' %}"></script>

--- a/semanticnews/templates/home.html
+++ b/semanticnews/templates/home.html
@@ -31,11 +31,6 @@
         <div class="col-12 col-md-4">
             <div class="d-flex justify-content-between align-items-center mb-2">
                 <h2 class="fs-5 mb-0">{%  trans "Agenda" %}</h2>
-                {% if user.is_authenticated %}
-                <button id="addEventBtn" class="btn btn-sm btn-outline-secondary" title="{% trans 'Add event' %}">
-                    <i class="bi bi-plus-lg"></i>
-                </button>
-                {% endif %}
             </div>
             {% for event in events %}
                 {% include "agenda/event_list_item.html" %}
@@ -50,16 +45,9 @@
 
 {% include "topics/create_topic_modal.html" %}
 
-{% if user.is_authenticated %}
-  {% include "agenda/event_modal.html" %}
-{% endif %}
-
 {% endblock %}
 
 {% block extra_js %}
     {{ block.super }}
-    {% if user.is_authenticated %}
-    <script src="{% static 'agenda/event_modal.js' %}"></script>
-    {% endif %}
     {% include "topics/create_topic_js.html" %}
 {% endblock %}

--- a/semanticnews/topics/templates/topics/topics_detail.html
+++ b/semanticnews/topics/templates/topics/topics_detail.html
@@ -86,6 +86,7 @@
                 {% include "topics/narratives/button.html" %}
                 {% include "topics/images/button.html" %}
                 {% include "topics/relations/button.html" %}
+                {% include "topics/timeline/button.html" %}
                 {% include "topics/mcps/button.html" %}
             </div>
 
@@ -242,6 +243,7 @@
 {% include "topics/narratives/modal.html" %}
 {% include "topics/images/modal.html" %}
 {% include "topics/relations/modal.html" %}
+{% include "topics/timeline/modal.html" %}
 {% include "topics/create_topic_modal.html" %}
 
 {% endblock %}
@@ -256,5 +258,6 @@
     {% include "topics/narratives/scripts.html" %}
     {% include "topics/images/scripts.html" %}
     {% include "topics/relations/scripts.html" %}
+    {% include "topics/timeline/scripts.html" %}
     {% include "topics/mcps/scripts.html" %}
 {% endblock %}

--- a/semanticnews/topics/utils/timeline/templates/topics/timeline/button.html
+++ b/semanticnews/topics/utils/timeline/templates/topics/timeline/button.html
@@ -1,0 +1,8 @@
+{% load i18n %}
+<button
+    id="timelineButton"
+    class="btn btn-outline-secondary btn-sm"
+    data-bs-toggle="modal"
+    data-bs-target="#timelineModal"{% if topic.status == 'archived' %} disabled{% endif %}>
+    {% trans "Timeline" %}
+</button>

--- a/semanticnews/topics/utils/timeline/templates/topics/timeline/modal.html
+++ b/semanticnews/topics/utils/timeline/templates/topics/timeline/modal.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<div class="modal fade" id="eventModal" tabindex="-1" aria-hidden="true">
+<div class="modal fade" id="timelineModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">

--- a/semanticnews/topics/utils/timeline/templates/topics/timeline/scripts.html
+++ b/semanticnews/topics/utils/timeline/templates/topics/timeline/scripts.html
@@ -1,0 +1,2 @@
+{% load static %}
+<script src="{% static 'topics/timeline/event_modal.js' %}"></script>


### PR DESCRIPTION
## Summary
- add Timeline button in topic toolbar
- relocate Add Event modal and script under timeline utility and link to topic
- drop standalone event creation from home and agenda pages

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68c2c79f6b708328871b62ecb9a179e3