### PR TITLE
Add AI-driven timeline event suggestions

### DIFF
--- a/semanticnews/topics/api.py
+++ b/semanticnews/topics/api.py
@@ -7,6 +7,7 @@ from semanticnews.openai import OpenAI
 
 from .models import Topic
 from .utils.timeline.models import TopicEvent
+from .utils.timeline.api import router as timeline_router
 from .utils.recaps.api import router as recaps_router
 from .utils.narratives.api import router as narratives_router
 from .utils.mcps.api import router as mcps_router
@@ -21,6 +22,7 @@ api.add_router("/mcp", mcps_router)
 api.add_router("/image", images_router)
 api.add_router("/relation", relations_router)
 api.add_router("/data", data_router)
+api.add_router("/timeline", timeline_router)
 
 
 class TopicCreateRequest(Schema):

--- a/semanticnews/topics/utils/timeline/api.py
+++ b/semanticnews/topics/utils/timeline/api.py
@@ -1,0 +1,166 @@
+"""API endpoints for timeline event suggestions and creation."""
+
+from datetime import date
+from typing import List, Optional
+
+from ninja import Router, Schema
+from ninja.errors import HttpError
+
+from ...models import Topic
+from ....agenda.models import Category, Event, Source
+from .models import TopicEvent
+from ....openai import OpenAI
+
+
+router = Router()
+
+
+class TimelineSuggestedEvent(Schema):
+    """Schema representing an event suggested by the AI."""
+
+    title: str
+    date: date
+    categories: List[str] = []
+    sources: List[str] = []
+
+
+class TimelineEventList(Schema):
+    """Wrapper for a list of timeline events."""
+
+    events: List[TimelineSuggestedEvent] = []
+
+
+class TimelineSuggestRequest(Schema):
+    """Request body for suggesting events for a topic timeline."""
+
+    topic_uuid: str
+    start_date: Optional[date] = None
+    end_date: Optional[date] = None
+    locality: Optional[str] = None
+    related_event: Optional[str] = None
+    limit: int = 5
+
+
+@router.post("/suggest", response=List[TimelineSuggestedEvent])
+def suggest_topic_events(request, payload: TimelineSuggestRequest):
+    """Return AI-suggested events related to a topic."""
+
+    user = getattr(request, "user", None)
+    if not user or not user.is_authenticated:
+        raise HttpError(401, "Unauthorized")
+
+    try:
+        topic = Topic.objects.get(uuid=payload.topic_uuid)
+    except Topic.DoesNotExist:
+        raise HttpError(404, "Topic not found")
+
+    if payload.start_date and payload.end_date:
+        if payload.start_date == payload.end_date:
+            timeframe = f"on {payload.start_date:%Y-%m-%d}"
+        else:
+            timeframe = (
+                f"between {payload.start_date:%Y-%m-%d} and {payload.end_date:%Y-%m-%d}"
+            )
+    elif payload.start_date:
+        timeframe = f"since {payload.start_date:%Y-%m-%d}"
+    elif payload.end_date:
+        timeframe = f"until {payload.end_date:%Y-%m-%d}"
+    else:
+        timeframe = "recently"
+
+    if payload.locality:
+        timeframe += f" in {payload.locality}"
+
+    descriptor_parts = []
+    if payload.related_event:
+        descriptor_parts.append(f'related to "{payload.related_event}"')
+    descriptor_parts.append(timeframe)
+    descriptor = " ".join(descriptor_parts)
+
+    prompt = (
+        f"List the top {payload.limit} significant events related to the topic "
+        f"\"{topic.title}\" {descriptor}."
+        " Generate event titles as concise factual statements. "
+        "State the core fact directly and neutrally. "
+        "For each event, include a few source URLs as citations."
+    )
+
+    context = topic.build_context()
+    if context:
+        prompt += "\n\nContext:\n" + context
+
+    with OpenAI() as client:
+        response = client.responses.parse(
+            model="gpt-5",
+            tools=[{"type": "web_search_preview"}],
+            input=prompt,
+            text_format=TimelineEventList,
+        )
+
+    return response.output_parsed.events
+
+
+class TimelineCreateRequest(Schema):
+    """Request body for creating selected suggested events."""
+
+    topic_uuid: str
+    events: List[TimelineSuggestedEvent]
+
+
+class TimelineCreatedEvent(Schema):
+    """Data returned for an event created from suggestions."""
+
+    uuid: str
+    title: str
+    date: date
+
+
+@router.post("/create", response=List[TimelineCreatedEvent])
+def create_topic_events(request, payload: TimelineCreateRequest):
+    """Create events from AI suggestions and relate them to the topic."""
+
+    user = getattr(request, "user", None)
+    if not user or not user.is_authenticated:
+        raise HttpError(401, "Unauthorized")
+
+    try:
+        topic = Topic.objects.get(uuid=payload.topic_uuid)
+    except Topic.DoesNotExist:
+        raise HttpError(404, "Topic not found")
+
+    created: List[TimelineCreatedEvent] = []
+    for ev in payload.events:
+        event = Event.objects.create(
+            title=ev.title,
+            date=ev.date,
+            status="published",
+            created_by=user,
+        )
+
+        for url in ev.sources or []:
+            source_obj, _ = Source.objects.get_or_create(url=url)
+            event.sources.add(source_obj)
+
+        for name in ev.categories or []:
+            category, _ = Category.objects.get_or_create(name=name)
+            event.categories.add(category)
+
+        event.embedding = event.get_embedding()
+        if event.embedding is not None:
+            event.save(update_fields=["embedding"])
+
+        TopicEvent.objects.create(
+            topic=topic,
+            event=event,
+            source="agent",
+            created_by=user,
+        )
+
+        created.append(
+            TimelineCreatedEvent(
+                uuid=str(event.uuid), title=event.title, date=event.date
+            )
+        )
+
+    return created
+

--- a/semanticnews/topics/utils/timeline/static/topics/timeline/event_modal.js
+++ b/semanticnews/topics/utils/timeline/static/topics/timeline/event_modal.js
@@ -17,8 +17,8 @@ const CONFIDENCE_THRESHOLD = 0.85;
   const suggestedList = document.getElementById('suggestedEventsList');
   const publishBtn = document.getElementById('publishSelectedEventsBtn');
   const titleField = document.getElementById('suggestRelatedEvent');
-  const existingEventsEl = document.getElementById('exclude-events');
-  const existingEvents = existingEventsEl ? JSON.parse(existingEventsEl.textContent) : [];
+
+  let suggestions = [];
 
   const topicEl = document.querySelector('[data-topic-uuid]');
   const topicUuid = topicEl ? topicEl.dataset.topicUuid : null;
@@ -108,7 +108,7 @@ const CONFIDENCE_THRESHOLD = 0.85;
       publishBtn.disabled = true;
       if (fetchBtn) fetchBtn.disabled = true;
       try {
-        const payload = {};
+        const payload = { topic_uuid: topicUuid };
         const title = titleField ? titleField.value : '';
         if (title) payload.related_event = title;
         const locality = document.getElementById('suggestLocality').value;
@@ -117,44 +117,23 @@ const CONFIDENCE_THRESHOLD = 0.85;
         if (locality) payload.locality = locality;
         if (startDate) payload.start_date = startDate;
         if (endDate) payload.end_date = endDate;
-        const exclude = existingEvents.filter(ev => {
-          if (startDate && ev.date < startDate) return false;
-          if (endDate && ev.date > endDate) return false;
-          return true;
-        });
-        if (exclude.length) payload.exclude = exclude;
-        const res = await fetch('/api/agenda/suggest', {
+        const res = await fetch('/api/topics/timeline/suggest', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload)
         });
         const data = await res.json();
         if (Array.isArray(data) && data.length) {
-          const created = [];
-          for (const ev of data) {
-            const createRes = await fetch('/api/agenda/create', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({
-                title: ev.title,
-                date: ev.date,
-                categories: ev.categories,
-                sources: ev.sources,
-              }),
-            });
-            const createdEvent = await createRes.json();
-            ev.uuid = createdEvent.uuid;
-            created.push(ev);
-          }
+          suggestions = data;
           suggestedList.innerHTML = '';
-          created.forEach((ev, idx) => {
+          data.forEach((ev, idx) => {
             const wrapper = document.createElement('div');
             wrapper.className = 'form-check';
             const cb = document.createElement('input');
             cb.type = 'checkbox';
             cb.className = 'form-check-input';
             cb.id = `suggest${idx}`;
-            cb.value = ev.uuid;
+            cb.value = idx;
             const label = document.createElement('label');
             label.className = 'form-check-label';
             label.htmlFor = cb.id;
@@ -178,16 +157,13 @@ const CONFIDENCE_THRESHOLD = 0.85;
 
     publishBtn.addEventListener('click', async () => {
       const checked = suggestedList.querySelectorAll('input[type="checkbox"]:checked');
-      const uuids = Array.from(checked).map(cb => cb.value);
-      if (uuids.length) {
-        await fetch('/api/agenda/publish', {
+      const events = Array.from(checked).map(cb => suggestions[parseInt(cb.value, 10)]);
+      if (events.length) {
+        await fetch('/api/topics/timeline/create', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ uuids })
+          body: JSON.stringify({ topic_uuid: topicUuid, events })
         });
-        for (const uuid of uuids) {
-          await addEventToTopic(uuid);
-        }
       }
       modal.hide();
       window.location.reload();


### PR DESCRIPTION
## Summary
- add timeline API endpoints to suggest events for a topic and create selected events
- wire topics API to expose new timeline router
- update timeline modal to fetch suggestions and create events via new endpoints

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68c2d0afed0c83288c2a48023de1cbd4