### PR TITLE
feat: show related events in timeline modal

### DIFF
--- a/semanticnews/topics/utils/timeline/templates/topics/timeline/modal.html
+++ b/semanticnews/topics/utils/timeline/templates/topics/timeline/modal.html
@@ -9,7 +9,12 @@
       <div class="modal-body">
         <ul class="nav nav-tabs mb-3" id="eventModalTabs" role="tablist">
           <li class="nav-item" role="presentation">
-            <button class="nav-link active" id="create-tab" data-bs-toggle="tab" data-bs-target="#createPane" type="button" role="tab">
+            <button class="nav-link active" id="existing-tab" data-bs-toggle="tab" data-bs-target="#existingPane" type="button" role="tab">
+                {% trans "Add existing" %}
+            </button>
+          </li>
+          <li class="nav-item" role="presentation">
+            <button class="nav-link" id="create-tab" data-bs-toggle="tab" data-bs-target="#createPane" type="button" role="tab">
                 {% trans "Add new" %}
             </button>
           </li>
@@ -21,7 +26,14 @@
           </li>
         </ul>
         <div class="tab-content">
-          <div class="tab-pane fade show active" id="createPane" role="tabpanel">
+          <div class="tab-pane fade show active" id="existingPane" role="tabpanel">
+            <div id="relatedEventsList" class="mb-3"></div>
+            <div class="modal-footer px-0">
+              <button type="button" class="btn btn-primary" id="addRelatedEventsBtn" disabled>{% trans "Add selected" %}</button>
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Close" %}</button>
+            </div>
+          </div>
+          <div class="tab-pane fade" id="createPane" role="tabpanel">
             <form id="addEventForm">
               <div class="mb-3">
                 <label for="eventDate" class="form-label">{% trans "Date" %}</label>


### PR DESCRIPTION
## Summary
- add API endpoint to list events related to a topic using embedding similarity
- show related events in a new first tab in the timeline modal
- allow selecting existing events and linking them to the topic

## Testing
- `python manage.py test` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68c394988fc88328b5c1390791c411d9