### PR TITLE
Enable EasyMDE for recap and narrative modals

### DIFF
--- a/semanticnews/topics/templates/topics/topics_detail.html
+++ b/semanticnews/topics/templates/topics/topics_detail.html
@@ -4,6 +4,10 @@
 
 {% block title %}{{ topic.title }}{% endblock %}
 
+{% block extra_head %}
+    {{ block.super }}
+    <link rel="stylesheet" href="https://unpkg.com/easymde/dist/easymde.min.css">
+{% endblock %}
 
 {% block content %}
 
@@ -200,6 +204,7 @@
 
 {% block extra_js %}
     {{ block.super }}
+    <script src="https://unpkg.com/easymde/dist/easymde.min.js"></script>
     <script src="{% static 'topics/topic_events.js' %}"></script>
     <script src="{% static 'topics/topic_publish.js' %}"></script>
     <script src="{% static 'topics/generation_button.js' %}"></script>

--- a/semanticnews/topics/templates/topics/topics_detail_edit.html
+++ b/semanticnews/topics/templates/topics/topics_detail_edit.html
@@ -4,6 +4,10 @@
 
 {% block title %}{{ topic.title }}{% endblock %}
 
+{% block extra_head %}
+    {{ block.super }}
+    <link rel="stylesheet" href="https://unpkg.com/easymde/dist/easymde.min.css">
+{% endblock %}
 
 {% block content %}
 
@@ -234,6 +238,7 @@
 
 {% block extra_js %}
     {{ block.super }}
+    <script src="https://unpkg.com/easymde/dist/easymde.min.js"></script>
     <script src="{% static 'topics/topic_events.js' %}"></script>
     <script src="{% static 'topics/topic_publish.js' %}"></script>
     <script src="{% static 'topics/generation_button.js' %}"></script>

--- a/semanticnews/topics/utils/narratives/static/topics/narratives/topic_narrative.js
+++ b/semanticnews/topics/utils/narratives/static/topics/narratives/topic_narrative.js
@@ -25,5 +25,6 @@ document.addEventListener('DOMContentLoaded', () => {
     renderItem: (item, el) => { if (el) el.innerHTML = renderMarkdownLite(item.narrative || ''); },
     parseInput: (text) => ({ narrative: text }),
     controller,
+    useMarkdown: true,
   });
 });


### PR DESCRIPTION
## Summary
- load EasyMDE assets on topic detail pages
- use EasyMDE for recap textarea and keep submit button state in sync
- extend history helper to optionally use EasyMDE and enable it for narrative editor

## Testing
- `pytest` *(fails: Requested setting DATABASES, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_b_68c462cec6e88328a0e3a28d682e7e74