### PR TITLE
Fix markdown editor modal display

### DIFF
--- a/semanticnews/topics/static/topics/history.js
+++ b/semanticnews/topics/static/topics/history.js
@@ -20,6 +20,13 @@ window.setupTopicHistory = function (options) {
   const setValue = (v) => { if (easyMDE) easyMDE.value(v); else if (textarea) textarea.value = v; };
   const cardContainer = document.getElementById(`topic${capitalize(key)}Container`);
   const cardContent = document.getElementById(`topic${capitalize(key)}${cardSuffix}`);
+  const modalEl = document.getElementById(`${key}Modal`);
+
+  if (easyMDE && modalEl) {
+    modalEl.addEventListener('shown.bs.modal', () => {
+      easyMDE.codemirror.refresh();
+    });
+  }
 
   const pagerEl = document.getElementById(`${key}Pager`);
   const prevBtn = document.getElementById(`${key}Prev`);

--- a/semanticnews/topics/utils/recaps/static/topics/recaps/topic_recap.js
+++ b/semanticnews/topics/utils/recaps/static/topics/recaps/topic_recap.js
@@ -179,6 +179,12 @@ document.addEventListener('DOMContentLoaded', () => {
     ? bootstrap.Modal.getOrCreateInstance(recapModalEl)
     : null;
 
+  if (recapModalEl && recapMDE) {
+    recapModalEl.addEventListener('shown.bs.modal', () => {
+      recapMDE.codemirror.refresh();
+    });
+  }
+
   const afterPersistedChange = async () => {
     // After AI suggestion or manual Update, ensure pager/card/textarea/baseline are correct
     await reloadRecapsAndJumpToLatest();


### PR DESCRIPTION
## Summary
- Refresh EasyMDE editors when recap and narrative modals are shown so existing text is visible immediately
- Ensure recap modal also refreshes its editor upon opening

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68c47ceed9b4832898707e8a7f0405e1