### PR TITLE
Add AI-powered data search endpoint

### DIFF
--- a/semanticnews/topics/utils/data/api.py
+++ b/semanticnews/topics/utils/data/api.py
@@ -22,6 +22,18 @@ class TopicDataFetchResponse(Schema):
     name: str | None = None
 
 
+class TopicDataSearchRequest(Schema):
+    topic_uuid: str
+    description: str
+
+
+class TopicDataSearchResponse(Schema):
+    headers: List[str]
+    rows: List[List[str]]
+    name: str | None = None
+    sources: List[str]
+
+
 class TopicDataSaveRequest(Schema):
     topic_uuid: str
     url: str
@@ -38,6 +50,10 @@ class _TopicDataResponse(Schema):
     headers: List[str]
     rows: List[List[str]]
     name: str | None = None
+
+
+class _TopicDataSearchResponse(_TopicDataResponse):
+    sources: List[str]
 
 
 class TopicDataAnalyzeRequest(Schema):
@@ -115,8 +131,42 @@ def fetch_data(request, payload: TopicDataFetchRequest):
 
     return TopicDataFetchResponse(
         headers=response.output_parsed.headers,
+       rows=response.output_parsed.rows,
+        name=response.output_parsed.name,
+    )
+
+
+@router.post("/search", response=TopicDataSearchResponse)
+def search_data(request, payload: TopicDataSearchRequest):
+    user = getattr(request, "user", None)
+    if not user or not user.is_authenticated:
+        raise HttpError(401, "Unauthorized")
+
+    try:
+        Topic.objects.get(uuid=payload.topic_uuid)
+    except Topic.DoesNotExist:
+        raise HttpError(404, "Topic not found")
+
+    prompt = (
+        "Using web search, find tabular data that matches the following description and "
+        "return it as JSON with keys 'headers', 'rows', 'sources' (a list of URLs), and "
+        "optionally 'name'. Description: "
+        f"{payload.description}"
+    )
+
+    with OpenAI() as client:
+        response = client.responses.parse(
+            model="gpt-5",
+            input=prompt,
+            tools=[{"type": "web_search"}],
+            text_format=_TopicDataSearchResponse,
+        )
+
+    return TopicDataSearchResponse(
+        headers=response.output_parsed.headers,
         rows=response.output_parsed.rows,
         name=response.output_parsed.name,
+        sources=response.output_parsed.sources,
     )
 
 

--- a/semanticnews/topics/utils/data/tests.py
+++ b/semanticnews/topics/utils/data/tests.py
@@ -23,6 +23,7 @@ class TopicDataSearchAPITests(TestCase):
             rows=[["2023", "1.1"]],
             name="USD/TL Rates",
             sources=["https://example.com/data"],
+            explanation=None,
         )
         mock_client.responses.parse.return_value = mock_response
 
@@ -44,6 +45,48 @@ class TopicDataSearchAPITests(TestCase):
                 "rows": [["2023", "1.1"]],
                 "name": "USD/TL Rates",
                 "sources": ["https://example.com/data"],
+            },
+        )
+        self.assertNotIn("explanation", response.json())
+        mock_client.responses.parse.assert_called_once()
+
+    @patch("semanticnews.topics.utils.data.api.OpenAI")
+    def test_search_data_returns_explanation_when_needed(self, mock_openai):
+        User = get_user_model()
+        user = User.objects.create_user("user2", "user2@example.com", "password")
+        self.client.force_login(user)
+        topic = Topic.objects.create(title="Another", created_by=user)
+
+        mock_client = MagicMock()
+        mock_openai.return_value.__enter__.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.output_parsed = MagicMock(
+            headers=["Year", "USD/TL"],
+            rows=[["2019", "5.7"]],
+            name=None,
+            sources=["https://example.com/partial"],
+            explanation="Only five years of data were found",
+        )
+        mock_client.responses.parse.return_value = mock_response
+
+        payload = {
+            "topic_uuid": str(topic.uuid),
+            "description": "USD/TL for last 10 years",
+        }
+        response = self.client.post(
+            "/api/topics/data/search",
+            payload,
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "headers": ["Year", "USD/TL"],
+                "rows": [["2019", "5.7"]],
+                "sources": ["https://example.com/partial"],
+                "explanation": "Only five years of data were found",
             },
         )
         mock_client.responses.parse.assert_called_once()

--- a/semanticnews/topics/utils/data/tests.py
+++ b/semanticnews/topics/utils/data/tests.py
@@ -1,3 +1,66 @@
+from django.contrib.auth import get_user_model
 from django.test import TestCase
+from unittest.mock import MagicMock, patch
 
-# Create your tests here.
+from semanticnews.topics.models import Topic
+
+
+class TopicDataSearchAPITests(TestCase):
+    """Tests for the data search API endpoint."""
+
+    @patch("semanticnews.topics.utils.data.api.OpenAI")
+    def test_search_data_returns_table_and_sources(self, mock_openai):
+        User = get_user_model()
+        user = User.objects.create_user("user", "user@example.com", "password")
+        self.client.force_login(user)
+        topic = Topic.objects.create(title="My Topic", created_by=user)
+
+        mock_client = MagicMock()
+        mock_openai.return_value.__enter__.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.output_parsed = MagicMock(
+            headers=["Year", "USD/TL"],
+            rows=[["2023", "1.1"]],
+            name="USD/TL Rates",
+            sources=["https://example.com/data"],
+        )
+        mock_client.responses.parse.return_value = mock_response
+
+        payload = {
+            "topic_uuid": str(topic.uuid),
+            "description": "year over year USD/TL for the last 10 years",
+        }
+        response = self.client.post(
+            "/api/topics/data/search",
+            payload,
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "headers": ["Year", "USD/TL"],
+                "rows": [["2023", "1.1"]],
+                "name": "USD/TL Rates",
+                "sources": ["https://example.com/data"],
+            },
+        )
+        mock_client.responses.parse.assert_called_once()
+
+    def test_search_requires_authentication(self):
+        User = get_user_model()
+        user = User.objects.create_user("user", "user@example.com", "password")
+        topic = Topic.objects.create(title="Topic", created_by=user)
+
+        payload = {
+            "topic_uuid": str(topic.uuid),
+            "description": "year over year USD/TL",
+        }
+        response = self.client.post(
+            "/api/topics/data/search",
+            payload,
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 401)


### PR DESCRIPTION
## Summary
- enable AI web search to fetch tabular data from a description
- expose new `/search` endpoint returning dataset and sources
- test data search API behavior and auth requirements

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68c59c8d14ac83288ec0fa73c19b0901