### PR TITLE
feat: add data search option

### DIFF
--- a/semanticnews/topics/utils/data/static/topics/data/topic_data.js
+++ b/semanticnews/topics/utils/data/static/topics/data/topic_data.js
@@ -2,7 +2,14 @@ document.addEventListener('DOMContentLoaded', () => {
   const fetchBtn = document.getElementById('fetchDataBtn');
   const form = document.getElementById('dataForm');
   const urlInput = document.getElementById('dataUrl');
+  const descriptionInput = document.getElementById('dataDescription');
+  const urlWrapper = document.getElementById('dataUrlWrapper');
+  const descriptionWrapper = document.getElementById('dataDescriptionWrapper');
+  const modeRadios = document.querySelectorAll('input[name="data_mode"]');
   const preview = document.getElementById('dataPreview');
+  const sourcesWrapper = document.getElementById('dataSourcesWrapper');
+  const sourcesList = document.getElementById('dataSources');
+  const explanationEl = document.getElementById('dataExplanation');
   const nameInput = document.getElementById('dataName');
   const nameWrapper = document.getElementById('dataNameWrapper');
   const analyzeBtn = document.getElementById('analyzeDataBtn');
@@ -15,18 +22,52 @@ document.addEventListener('DOMContentLoaded', () => {
   const chartTypeSelect = document.getElementById('visualizeChartType');
   let fetchedData = null;
 
-  if (fetchBtn && urlInput) {
+  modeRadios.forEach((radio) => {
+    radio.addEventListener('change', () => {
+      if (radio.value === 'url' && radio.checked) {
+        if (urlWrapper) urlWrapper.classList.remove('d-none');
+        if (descriptionWrapper) descriptionWrapper.classList.add('d-none');
+      } else if (radio.value === 'search' && radio.checked) {
+        if (descriptionWrapper) descriptionWrapper.classList.remove('d-none');
+        if (urlWrapper) urlWrapper.classList.add('d-none');
+      }
+    });
+  });
+
+  if (fetchBtn) {
     fetchBtn.addEventListener('click', async () => {
       fetchBtn.disabled = true;
       const topicUuid = form.querySelector('input[name="topic_uuid"]').value;
+      const modeEl = document.querySelector('input[name="data_mode"]:checked');
+      const mode = modeEl ? modeEl.value : 'url';
+      const body = { topic_uuid: topicUuid };
+      let endpoint = '/api/topics/data/fetch';
+      if (mode === 'url') {
+        if (!urlInput || !urlInput.value) {
+          fetchBtn.disabled = false;
+          return;
+        }
+        body.url = urlInput.value;
+      } else {
+        endpoint = '/api/topics/data/search';
+        const description = descriptionInput ? descriptionInput.value.trim() : '';
+        if (!description) {
+          fetchBtn.disabled = false;
+          return;
+        }
+        body.description = description;
+      }
       try {
-        const res = await fetch('/api/topics/data/fetch', {
+        const res = await fetch(endpoint, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ topic_uuid: topicUuid, url: urlInput.value })
+          body: JSON.stringify(body)
         });
         if (!res.ok) throw new Error('Request failed');
         fetchedData = await res.json();
+        fetchedData.url = mode === 'url'
+          ? (urlInput ? urlInput.value : '')
+          : (fetchedData.sources && fetchedData.sources.length > 0 ? fetchedData.sources[0] : '');
         if (nameInput) {
           nameInput.value = fetchedData.name || '';
           if (nameWrapper) nameWrapper.classList.remove('d-none');
@@ -39,6 +80,33 @@ document.addEventListener('DOMContentLoaded', () => {
         });
         html += '</tbody></table>';
         preview.innerHTML = html;
+        if (mode === 'search') {
+          if (sourcesWrapper && sourcesList) {
+            if (fetchedData.sources && fetchedData.sources.length > 0) {
+              sourcesList.innerHTML = fetchedData.sources.map(src => `<li><a href="${src}" target="_blank">${src}</a></li>`).join('');
+              sourcesWrapper.classList.remove('d-none');
+            } else {
+              sourcesList.innerHTML = '';
+              sourcesWrapper.classList.add('d-none');
+            }
+          }
+          if (explanationEl) {
+            if (fetchedData.explanation) {
+              explanationEl.textContent = fetchedData.explanation;
+              explanationEl.classList.remove('d-none');
+            } else {
+              explanationEl.classList.add('d-none');
+              explanationEl.textContent = '';
+            }
+          }
+        } else {
+          if (sourcesWrapper) sourcesWrapper.classList.add('d-none');
+          if (sourcesList) sourcesList.innerHTML = '';
+          if (explanationEl) {
+            explanationEl.classList.add('d-none');
+            explanationEl.textContent = '';
+          }
+        }
       } catch (err) {
         console.error(err);
       } finally {
@@ -52,7 +120,7 @@ document.addEventListener('DOMContentLoaded', () => {
       e.preventDefault();
       if (!fetchedData) return;
       const topicUuid = form.querySelector('input[name="topic_uuid"]').value;
-      const url = urlInput.value;
+      const url = fetchedData.url || (urlInput ? urlInput.value : '');
       const res = await fetch('/api/topics/data/create', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/semanticnews/topics/utils/data/templates/topics/data/modal.html
+++ b/semanticnews/topics/utils/data/templates/topics/data/modal.html
@@ -10,8 +10,22 @@
                 <form id="dataForm">
                     <input type="hidden" name="topic_uuid" value="{{ topic.uuid }}">
                     <div class="mb-3">
+                        <div class="form-check">
+                            <input class="form-check-input" type="radio" name="data_mode" id="dataModeUrl" value="url" checked>
+                            <label class="form-check-label" for="dataModeUrl">{% trans "Fetch from URL" %}</label>
+                        </div>
+                        <div class="form-check">
+                            <input class="form-check-input" type="radio" name="data_mode" id="dataModeSearch" value="search">
+                            <label class="form-check-label" for="dataModeSearch">{% trans "Describe data" %}</label>
+                        </div>
+                    </div>
+                    <div class="mb-3" id="dataUrlWrapper">
                         <label for="dataUrl" class="form-label">{% trans "Data source URL" %}</label>
                         <input type="url" class="form-control" id="dataUrl" name="url">
+                    </div>
+                    <div class="mb-3 d-none" id="dataDescriptionWrapper">
+                        <label for="dataDescription" class="form-label">{% trans "Data description" %}</label>
+                        <textarea class="form-control" id="dataDescription" name="description" rows="3"></textarea>
                     </div>
                     <div class="mb-3 d-none" id="dataNameWrapper">
                         <label for="dataName" class="form-label">{% trans "Data name" %}</label>
@@ -19,6 +33,11 @@
                     </div>
                     <div class="mb-3">
                         <div id="dataPreview" class="table-responsive"></div>
+                        <div id="dataSourcesWrapper" class="d-none">
+                            <label class="form-label">{% trans "Sources" %}</label>
+                            <ul id="dataSources" class="small mb-0"></ul>
+                        </div>
+                        <div id="dataExplanation" class="small text-muted d-none"></div>
                     </div>
                     <div class="modal-footer px-0">
                         <button type="button" class="btn btn-outline-secondary float-start me-auto" id="fetchDataBtn">


### PR DESCRIPTION
## Summary
- allow choosing between fetching data via URL or searching by description
- show resulting sources and optional explanation in the Add Data modal

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68c5ac23316483289941f484633063be