### PR TITLE
feat: add data search option

### DIFF
--- a/semanticnews/topics/utils/data/templates/topics/data/modal.html
+++ b/semanticnews/topics/utils/data/templates/topics/data/modal.html
@@ -10,8 +10,18 @@
                 <form id="dataForm">
                     <input type="hidden" name="topic_uuid" value="{{ topic.uuid }}">
                     <div class="mb-3">
-                        <label for="dataUrl" class="form-label">{% trans "Data source URL" %}</label>
-                        <input type="url" class="form-control" id="dataUrl" name="url">
+                        <div class="form-check">
+                            <input class="form-check-input" type="radio" name="data_mode" id="dataModeUrl" value="url" checked>
+                            <label class="form-check-label" for="dataModeUrl">{% trans "Fetch from URL" %}</label>
+                        </div>
+                        <input type="url" class="form-control mt-2" id="dataUrl" name="url">
+                    </div>
+                    <div class="mb-3">
+                        <div class="form-check">
+                            <input class="form-check-input" type="radio" name="data_mode" id="dataModeSearch" value="search">
+                            <label class="form-check-label" for="dataModeSearch">{% trans "Describe data" %}</label>
+                        </div>
+                        <textarea class="form-control mt-2" id="dataDescription" name="description" rows="3"></textarea>
                     </div>
                     <div class="mb-3 d-none" id="dataNameWrapper">
                         <label for="dataName" class="form-label">{% trans "Data name" %}</label>
@@ -19,6 +29,11 @@
                     </div>
                     <div class="mb-3">
                         <div id="dataPreview" class="table-responsive"></div>
+                        <div id="dataSourcesWrapper" class="d-none">
+                            <label class="form-label">{% trans "Sources" %}</label>
+                            <ul id="dataSources" class="small mb-0"></ul>
+                        </div>
+                        <div id="dataExplanation" class="small text-muted d-none"></div>
                     </div>
                     <div class="modal-footer px-0">
                         <button type="button" class="btn btn-outline-secondary float-start me-auto" id="fetchDataBtn">


### PR DESCRIPTION
## Summary
- allow choosing between fetching data via URL or searching by description
- show resulting sources and optional explanation in the Add Data modal
- always display URL and description fields below their respective radio labels

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68c5ac23316483289941f484633063be