### PR TITLE
feat: add data search option

### DIFF
--- a/semanticnews/topics/utils/data/static/topics/data/topic_data.js
+++ b/semanticnews/topics/utils/data/static/topics/data/topic_data.js
@@ -2,7 +2,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const fetchBtn = document.getElementById('fetchDataBtn');
   const form = document.getElementById('dataForm');
   const urlInput = document.getElementById('dataUrl');
+  const descriptionInput = document.getElementById('dataDescription');
   const preview = document.getElementById('dataPreview');
+  const sourcesWrapper = document.getElementById('dataSourcesWrapper');
+  const sourcesList = document.getElementById('dataSources');
+  const explanationEl = document.getElementById('dataExplanation');
   const nameInput = document.getElementById('dataName');
   const nameWrapper = document.getElementById('dataNameWrapper');
   const analyzeBtn = document.getElementById('analyzeDataBtn');
@@ -13,20 +17,56 @@ document.addEventListener('DOMContentLoaded', () => {
   const visualizeForm = document.getElementById('dataVisualizeForm');
   const visualizeOtherInput = document.getElementById('visualizeInsightOtherText');
   const chartTypeSelect = document.getElementById('visualizeChartType');
+  const urlMode = document.getElementById('dataModeUrl');
+  const searchMode = document.getElementById('dataModeSearch');
   let fetchedData = null;
 
-  if (fetchBtn && urlInput) {
+  if (urlInput && urlMode) {
+    urlInput.addEventListener('focus', () => {
+      urlMode.checked = true;
+    });
+  }
+
+  if (descriptionInput && searchMode) {
+    descriptionInput.addEventListener('focus', () => {
+      searchMode.checked = true;
+    });
+  }
+
+  if (fetchBtn) {
     fetchBtn.addEventListener('click', async () => {
       fetchBtn.disabled = true;
       const topicUuid = form.querySelector('input[name="topic_uuid"]').value;
+      const modeEl = document.querySelector('input[name="data_mode"]:checked');
+      const mode = modeEl ? modeEl.value : 'url';
+      const body = { topic_uuid: topicUuid };
+      let endpoint = '/api/topics/data/fetch';
+      if (mode === 'url') {
+        if (!urlInput || !urlInput.value) {
+          fetchBtn.disabled = false;
+          return;
+        }
+        body.url = urlInput.value;
+      } else {
+        endpoint = '/api/topics/data/search';
+        const description = descriptionInput ? descriptionInput.value.trim() : '';
+        if (!description) {
+          fetchBtn.disabled = false;
+          return;
+        }
+        body.description = description;
+      }
       try {
-        const res = await fetch('/api/topics/data/fetch', {
+        const res = await fetch(endpoint, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ topic_uuid: topicUuid, url: urlInput.value })
+          body: JSON.stringify(body)
         });
         if (!res.ok) throw new Error('Request failed');
         fetchedData = await res.json();
+        fetchedData.url = mode === 'url'
+          ? (urlInput ? urlInput.value : '')
+          : (fetchedData.sources && fetchedData.sources.length > 0 ? fetchedData.sources[0] : '');
         if (nameInput) {
           nameInput.value = fetchedData.name || '';
           if (nameWrapper) nameWrapper.classList.remove('d-none');
@@ -39,6 +79,33 @@ document.addEventListener('DOMContentLoaded', () => {
         });
         html += '</tbody></table>';
         preview.innerHTML = html;
+        if (mode === 'search') {
+          if (sourcesWrapper && sourcesList) {
+            if (fetchedData.sources && fetchedData.sources.length > 0) {
+              sourcesList.innerHTML = fetchedData.sources.map(src => `<li><a href="${src}" target="_blank">${src}</a></li>`).join('');
+              sourcesWrapper.classList.remove('d-none');
+            } else {
+              sourcesList.innerHTML = '';
+              sourcesWrapper.classList.add('d-none');
+            }
+          }
+          if (explanationEl) {
+            if (fetchedData.explanation) {
+              explanationEl.textContent = fetchedData.explanation;
+              explanationEl.classList.remove('d-none');
+            } else {
+              explanationEl.classList.add('d-none');
+              explanationEl.textContent = '';
+            }
+          }
+        } else {
+          if (sourcesWrapper) sourcesWrapper.classList.add('d-none');
+          if (sourcesList) sourcesList.innerHTML = '';
+          if (explanationEl) {
+            explanationEl.classList.add('d-none');
+            explanationEl.textContent = '';
+          }
+        }
       } catch (err) {
         console.error(err);
       } finally {
@@ -52,7 +119,7 @@ document.addEventListener('DOMContentLoaded', () => {
       e.preventDefault();
       if (!fetchedData) return;
       const topicUuid = form.querySelector('input[name="topic_uuid"]').value;
-      const url = urlInput.value;
+      const url = fetchedData.url || (urlInput ? urlInput.value : '');
       const res = await fetch('/api/topics/data/create', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/semanticnews/topics/utils/data/templates/topics/data/modal.html
+++ b/semanticnews/topics/utils/data/templates/topics/data/modal.html
@@ -10,8 +10,18 @@
                 <form id="dataForm">
                     <input type="hidden" name="topic_uuid" value="{{ topic.uuid }}">
                     <div class="mb-3">
-                        <label for="dataUrl" class="form-label">{% trans "Data source URL" %}</label>
-                        <input type="url" class="form-control" id="dataUrl" name="url">
+                        <div class="form-check">
+                            <input class="form-check-input" type="radio" name="data_mode" id="dataModeUrl" value="url" checked>
+                            <label class="form-check-label" for="dataModeUrl">{% trans "Fetch from URL" %}</label>
+                            <input type="url" class="form-control mt-2" id="dataUrl" name="url" placeholder="https://example.com/data.csv">
+                        </div>
+                    </div>
+                    <div class="mb-3">
+                        <div class="form-check">
+                            <input class="form-check-input" type="radio" name="data_mode" id="dataModeSearch" value="search">
+                            <label class="form-check-label" for="dataModeSearch">{% trans "Describe data" %}</label>
+                            <textarea class="form-control mt-2" id="dataDescription" name="description" rows="3" placeholder="{% trans 'Describe the data you need' %}"></textarea>
+                        </div>
                     </div>
                     <div class="mb-3 d-none" id="dataNameWrapper">
                         <label for="dataName" class="form-label">{% trans "Data name" %}</label>
@@ -19,6 +29,11 @@
                     </div>
                     <div class="mb-3">
                         <div id="dataPreview" class="table-responsive"></div>
+                        <div id="dataSourcesWrapper" class="d-none">
+                            <label class="form-label">{% trans "Sources" %}</label>
+                            <ul id="dataSources" class="small mb-0"></ul>
+                        </div>
+                        <div id="dataExplanation" class="small text-muted d-none"></div>
                     </div>
                     <div class="modal-footer px-0">
                         <button type="button" class="btn btn-outline-secondary float-start me-auto" id="fetchDataBtn">


### PR DESCRIPTION
## Summary
- allow choosing between fetching data via URL or searching by description
- show resulting sources and optional explanation in the Add Data modal
- always display URL and description fields below their respective radio labels
- automatically select the related radio when a URL or description field gains focus

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68c5ac23316483289941f484633063be