### PR TITLE
Add YouTube media API endpoint

### DIFF
--- a/semanticnews/topics/utils/media/api.py
+++ b/semanticnews/topics/utils/media/api.py
@@ -1,5 +1,6 @@
-from typing import List
+from typing import Dict, Callable, Optional
 
+from django.utils import timezone
 from ninja import Router, Schema
 from ninja.errors import HttpError
 
@@ -7,4 +8,73 @@ from ...models import Topic
 from .models import TopicYoutubeVideo
 
 router = Router()
+
+
+def _extract_youtube_id(url: str) -> Optional[str]:
+    """Extract the YouTube video ID from a URL."""
+    from urllib.parse import urlparse, parse_qs
+
+    parsed = urlparse(url)
+    if parsed.hostname in {"youtu.be", "www.youtu.be"}:
+        return parsed.path.lstrip("/")
+    if parsed.hostname and "youtube" in parsed.hostname:
+        if parsed.path.startswith("/embed/"):
+            return parsed.path.split("/")[2]
+        qs = parse_qs(parsed.query)
+        if "v" in qs:
+            return qs["v"][0]
+    return None
+
+
+class TopicMediaAddRequest(Schema):
+    topic_uuid: str
+    media_type: str
+    url: str
+
+
+class TopicMediaAddResponse(Schema):
+    id: int
+    media_type: str
+    url: str
+
+
+def _add_youtube_video(topic: Topic, url: str) -> TopicYoutubeVideo:
+    video_id = _extract_youtube_id(url)
+    if not video_id:
+        raise HttpError(400, "Invalid YouTube URL")
+    return TopicYoutubeVideo.objects.create(
+        topic=topic,
+        url=url,
+        video_id=video_id,
+        title=video_id,
+        description="",
+        published_at=timezone.now(),
+    )
+
+
+_HANDLERS: Dict[str, Callable[[Topic, str], TopicYoutubeVideo]] = {
+    "youtube": _add_youtube_video,
+}
+
+
+@router.post("/add", response=TopicMediaAddResponse)
+def add_media(request, payload: TopicMediaAddRequest):
+    user = getattr(request, "user", None)
+    if not user or not user.is_authenticated:
+        raise HttpError(401, "Unauthorized")
+
+    try:
+        topic = Topic.objects.get(uuid=payload.topic_uuid)
+    except Topic.DoesNotExist:
+        raise HttpError(404, "Topic not found")
+
+    if topic.created_by_id != user.id:
+        raise HttpError(403, "Forbidden")
+
+    handler = _HANDLERS.get(payload.media_type)
+    if not handler:
+        raise HttpError(400, "Unsupported media type")
+
+    media = handler(topic, payload.url)
+    return TopicMediaAddResponse(id=media.id, media_type=payload.media_type, url=media.url)
 

--- a/semanticnews/topics/utils/media/tests.py
+++ b/semanticnews/topics/utils/media/tests.py
@@ -2,7 +2,7 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 
 from ...models import Topic
-from .models import TopicMedia
+from .models import TopicYoutubeVideo
 
 
 class TopicMediaAPITests(TestCase):
@@ -23,6 +23,7 @@ class TopicMediaAPITests(TestCase):
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(TopicMedia.objects.count(), 1)
-        media = TopicMedia.objects.first()
+        self.assertEqual(TopicYoutubeVideo.objects.count(), 1)
+        media = TopicYoutubeVideo.objects.first()
         self.assertEqual(media.url, payload["url"])
+        self.assertEqual(media.video_id, "dQw4w9WgXcQ")


### PR DESCRIPTION
## Summary
- add generic media endpoint and YouTube video handler for topics
- test YouTube video media endpoint

## Testing
- `python manage.py test semanticnews.topics.utils.media -v 2` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68c7dcda52d083288f4c8a4069495747