### PR TITLE
Add media toolbar button for YouTube videos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@
 *.pyc
 media/
 !semanticnews/topics/utils/media/
+!semanticnews/topics/utils/media/**
+__pycache__/
 !.env.example

--- a/semanticnews/topics/templates/topics/topics_detail_edit.html
+++ b/semanticnews/topics/templates/topics/topics_detail_edit.html
@@ -95,6 +95,7 @@
             {% include "topics/data/button.html" %}
             {% include "topics/narratives/button.html" %}
             {% include "topics/images/button.html" %}
+            {% include "topics/media/button.html" %}
             {% include "topics/relations/button.html" %}
             {% include "topics/timeline/button.html" %}
             {% include "topics/mcps/button.html" %}
@@ -209,6 +210,7 @@
 {% include "topics/data/visualize_modal.html" %}
 {% include "topics/narratives/modal.html" %}
 {% include "topics/images/modal.html" %}
+{% include "topics/media/modal.html" %}
 {% include "topics/relations/modal.html" %}
 {% include "topics/timeline/modal.html" %}
 {% include "topics/create_topic_modal.html" %}
@@ -226,6 +228,7 @@
     {% include "topics/data/scripts.html" %}
     {% include "topics/narratives/scripts.html" %}
     {% include "topics/images/scripts.html" %}
+    {% include "topics/media/scripts.html" %}
     {% include "topics/relations/scripts.html" %}
     {% include "topics/timeline/scripts.html" %}
     {% include "topics/mcps/scripts.html" %}

--- a/semanticnews/topics/utils/media/static/topics/media/topic_media.js
+++ b/semanticnews/topics/utils/media/static/topics/media/topic_media.js
@@ -1,0 +1,34 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('youtubeVideoForm');
+  if (form) {
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const submitBtn = form.querySelector('button[type="submit"]');
+      submitBtn.disabled = true;
+      const modalEl = document.getElementById('youtubeVideoModal');
+      if (modalEl && window.bootstrap) {
+        const modal = window.bootstrap.Modal.getInstance(modalEl);
+        if (modal) modal.hide();
+      }
+      const formData = new FormData(form);
+      const payload = {
+        topic_uuid: formData.get('topic_uuid'),
+        media_type: 'youtube',
+        url: formData.get('url')
+      };
+      try {
+        const res = await fetch('/api/topics/media/add', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        if (!res.ok) throw new Error('Request failed');
+        await res.json();
+        window.location.reload();
+      } catch (err) {
+        console.error(err);
+        submitBtn.disabled = false;
+      }
+    });
+  }
+});

--- a/semanticnews/topics/utils/media/templates/topics/media/button.html
+++ b/semanticnews/topics/utils/media/templates/topics/media/button.html
@@ -1,0 +1,11 @@
+{% load i18n %}
+<div class="btn-group">
+  <button id="mediaButton" class="btn btn-outline-secondary btn-sm dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"{% if topic.status == 'archived' %} disabled{% endif %}>
+    {% trans "Media" %}
+  </button>
+  <ul class="dropdown-menu">
+    <li>
+      <button type="button" class="dropdown-item" data-bs-toggle="modal" data-bs-target="#youtubeVideoModal">{% trans "Youtube video" %}</button>
+    </li>
+  </ul>
+</div>

--- a/semanticnews/topics/utils/media/templates/topics/media/modal.html
+++ b/semanticnews/topics/utils/media/templates/topics/media/modal.html
@@ -1,0 +1,24 @@
+{% load i18n %}
+<div class="modal fade" id="youtubeVideoModal" tabindex="-1" aria-labelledby="youtubeVideoModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form id="youtubeVideoForm">
+        <div class="modal-header">
+          <h1 class="modal-title fs-5" id="youtubeVideoModalLabel">{% trans "Add Youtube video" %}</h1>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans 'Close' %}"></button>
+        </div>
+        <div class="modal-body">
+          <input type="hidden" name="topic_uuid" value="{{ topic.uuid }}">
+          <div class="mb-3">
+            <label for="youtubeUrl" class="form-label">{% trans "Video URL" %}</label>
+            <input type="url" class="form-control" id="youtubeUrl" name="url" required>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Cancel" %}</button>
+          <button type="submit" class="btn btn-primary">{% trans "Add" %}</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/semanticnews/topics/utils/media/templates/topics/media/scripts.html
+++ b/semanticnews/topics/utils/media/templates/topics/media/scripts.html
@@ -1,0 +1,2 @@
+{% load static %}
+<script src="{% static 'topics/media/topic_media.js' %}"></script>


### PR DESCRIPTION
## Summary
- add Media toolbar button with YouTube video option
- support adding YouTube videos via modal and API fetching details
- test media API with mocked video metadata

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68c7df2d32148328bf78b24b86f727a1