### PR TITLE
Hide recap navigation when only one entry

### DIFF
--- a/semanticnews/topics/static/topics/history.js
+++ b/semanticnews/topics/static/topics/history.js
@@ -38,6 +38,7 @@ window.setupTopicHistory = function (options) {
   const pagerLabel = document.getElementById(`${key}PagerLabel`);
   const createdAtEl = document.getElementById(`${key}CreatedAt`);
   const deleteBtn = document.getElementById(`${key}DeleteBtn`);
+  const hideWhenSingleEls = pagerEl ? Array.from(pagerEl.querySelectorAll('[data-hide-when-single]')) : [];
 
   const confirmModalEl = document.getElementById(`confirmDelete${capitalize(key)}Modal`);
   const confirmBtn = document.getElementById(`confirmDelete${capitalize(key)}Btn`);
@@ -97,6 +98,14 @@ window.setupTopicHistory = function (options) {
     // Pager/UI
     pagerEl && (pagerEl.style.display = '');
     pagerLabel && (pagerLabel.textContent = `${currentIndex + 1}/${recs.length}`);
+    const hasMultiple = recs.length > 1;
+    hideWhenSingleEls.forEach((el) => {
+      if (hasMultiple) {
+        el.classList.remove('d-none');
+      } else {
+        el.classList.add('d-none');
+      }
+    });
     prevBtn && (prevBtn.disabled = currentIndex <= 0);
     nextBtn && (nextBtn.disabled = currentIndex >= recs.length - 1);
     createdAtEl && (createdAtEl.textContent = formatDateTime(item.created_at));

--- a/semanticnews/topics/utils/recaps/templates/topics/recaps/card.html
+++ b/semanticnews/topics/utils/recaps/templates/topics/recaps/card.html
@@ -9,11 +9,11 @@
             {% if edit_mode %}
                 <div class="d-flex align-items-center gap-2" id="recapPager" style="display:none;">
                     <span class="small text-secondary me-2" id="recapCreatedAt"></span>
-                    <button class="btn btn-sm btn-outline-secondary" id="recapPrev"
+                    <button class="btn btn-sm btn-outline-secondary" id="recapPrev" data-hide-when-single
                             aria-label="{% trans 'Previous recap' %}">&lt;
                     </button>
                     <span class="small text-secondary" id="recapPagerLabel">0/0</span>
-                    <button class="btn btn-sm btn-outline-secondary" id="recapNext"
+                    <button class="btn btn-sm btn-outline-secondary" id="recapNext" data-hide-when-single
                             aria-label="{% trans 'Next recap' %}">&gt;
                     </button>
                     <button class="btn btn-sm btn-outline-danger" id="recapDeleteBtn"


### PR DESCRIPTION
## Summary
- add markers to the recap pager navigation buttons so they can be conditionally hidden
- update the shared history helper to hide buttons that should not appear when there is only one item

## Testing
- python manage.py test *(fails: database connection refused in the container environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c8eceacda08328a56bcb806b6678a8