### PR TITLE
Add API endpoints for topic documents utility

### DIFF
--- a/semanticnews/topics/api.py
+++ b/semanticnews/topics/api.py
@@ -17,6 +17,7 @@ from .utils.images.api import router as images_router
 from .utils.embeds.api import router as embeds_router
 from .utils.relations.api import router as relations_router
 from .utils.data.api import router as data_router
+from .utils.documents.api import router as documents_router
 
 api = NinjaAPI(title="Topics API", urls_namespace="topics")
 api.add_router("/recap", recaps_router)
@@ -26,6 +27,7 @@ api.add_router("/image", images_router)
 api.add_router("/embed", embeds_router)
 api.add_router("/relation", relations_router)
 api.add_router("/data", data_router)
+api.add_router("/document", documents_router)
 api.add_router("/timeline", timeline_router)
 
 StatusLiteral = Literal["in_progress", "finished", "error"]

--- a/semanticnews/topics/utils/documents/api.py
+++ b/semanticnews/topics/utils/documents/api.py
@@ -1,0 +1,245 @@
+"""API endpoints for managing topic documents and webpages."""
+
+from datetime import datetime
+from typing import List, Optional
+
+from django.utils.timezone import make_naive
+from ninja import Router, Schema
+from ninja.errors import HttpError
+
+from ...models import Topic
+from .models import TopicDocument, TopicWebpage
+
+
+router = Router()
+
+
+class TopicDocumentCreateRequest(Schema):
+    """Payload for creating a new document link."""
+
+    topic_uuid: str
+    url: str
+    title: Optional[str] = None
+    description: Optional[str] = None
+
+
+class TopicDocumentResponse(Schema):
+    """Representation of a stored document link."""
+
+    id: int
+    title: Optional[str] = None
+    url: str
+    description: Optional[str] = None
+    document_type: str
+    domain: str
+    created_at: datetime
+
+
+class TopicDocumentListResponse(Schema):
+    """List response for topic documents."""
+
+    total: int
+    items: List[TopicDocumentResponse]
+
+
+@router.post("/create", response=TopicDocumentResponse)
+def create_document(request, payload: TopicDocumentCreateRequest):
+    """Add a new document link to a topic owned by the current user."""
+
+    user = getattr(request, "user", None)
+    if not user or not user.is_authenticated:
+        raise HttpError(401, "Unauthorized")
+
+    try:
+        topic = Topic.objects.get(uuid=payload.topic_uuid)
+    except Topic.DoesNotExist:
+        raise HttpError(404, "Topic not found")
+
+    if topic.created_by_id != user.id:
+        raise HttpError(403, "Forbidden")
+
+    document = TopicDocument.objects.create(
+        topic=topic,
+        url=payload.url,
+        title=payload.title or "",
+        description=payload.description or "",
+        created_by=user,
+    )
+
+    return TopicDocumentResponse(
+        id=document.id,
+        title=document.title or None,
+        url=document.url,
+        description=document.description or None,
+        document_type=document.document_type,
+        domain=document.domain,
+        created_at=make_naive(document.created_at),
+    )
+
+
+@router.get("/{topic_uuid}/list", response=TopicDocumentListResponse)
+def list_documents(request, topic_uuid: str):
+    """Return the list of documents for a topic owned by the user."""
+
+    user = getattr(request, "user", None)
+    if not user or not user.is_authenticated:
+        raise HttpError(401, "Unauthorized")
+
+    try:
+        topic = Topic.objects.get(uuid=topic_uuid)
+    except Topic.DoesNotExist:
+        raise HttpError(404, "Topic not found")
+
+    if topic.created_by_id != user.id:
+        raise HttpError(403, "Forbidden")
+
+    documents = TopicDocument.objects.filter(topic=topic).order_by("-created_at")
+
+    items = [
+        TopicDocumentResponse(
+            id=document.id,
+            title=document.title or None,
+            url=document.url,
+            description=document.description or None,
+            document_type=document.document_type,
+            domain=document.domain,
+            created_at=make_naive(document.created_at),
+        )
+        for document in documents
+    ]
+
+    return TopicDocumentListResponse(total=len(items), items=items)
+
+
+@router.delete("/{document_id}", response={204: None})
+def delete_document(request, document_id: int):
+    """Remove a document link from a topic owned by the user."""
+
+    user = getattr(request, "user", None)
+    if not user or not user.is_authenticated:
+        raise HttpError(401, "Unauthorized")
+
+    try:
+        document = TopicDocument.objects.select_related("topic").get(id=document_id)
+    except TopicDocument.DoesNotExist:
+        raise HttpError(404, "Document not found")
+
+    if document.topic.created_by_id != user.id:
+        raise HttpError(403, "Forbidden")
+
+    document.delete()
+    return 204, None
+
+
+class TopicWebpageCreateRequest(Schema):
+    """Payload for creating a new webpage link."""
+
+    topic_uuid: str
+    url: str
+    title: Optional[str] = None
+    description: Optional[str] = None
+
+
+class TopicWebpageResponse(Schema):
+    """Representation of a stored webpage link."""
+
+    id: int
+    title: Optional[str] = None
+    url: str
+    description: Optional[str] = None
+    domain: str
+    created_at: datetime
+
+
+class TopicWebpageListResponse(Schema):
+    """List response for topic webpages."""
+
+    total: int
+    items: List[TopicWebpageResponse]
+
+
+@router.post("/webpage/create", response=TopicWebpageResponse)
+def create_webpage(request, payload: TopicWebpageCreateRequest):
+    """Add a new webpage link to a topic owned by the current user."""
+
+    user = getattr(request, "user", None)
+    if not user or not user.is_authenticated:
+        raise HttpError(401, "Unauthorized")
+
+    try:
+        topic = Topic.objects.get(uuid=payload.topic_uuid)
+    except Topic.DoesNotExist:
+        raise HttpError(404, "Topic not found")
+
+    if topic.created_by_id != user.id:
+        raise HttpError(403, "Forbidden")
+
+    webpage = TopicWebpage.objects.create(
+        topic=topic,
+        url=payload.url,
+        title=payload.title or "",
+        description=payload.description or "",
+        created_by=user,
+    )
+
+    return TopicWebpageResponse(
+        id=webpage.id,
+        title=webpage.title or None,
+        url=webpage.url,
+        description=webpage.description or None,
+        domain=webpage.domain,
+        created_at=make_naive(webpage.created_at),
+    )
+
+
+@router.get("/webpage/{topic_uuid}/list", response=TopicWebpageListResponse)
+def list_webpages(request, topic_uuid: str):
+    """Return the list of webpages for a topic owned by the user."""
+
+    user = getattr(request, "user", None)
+    if not user or not user.is_authenticated:
+        raise HttpError(401, "Unauthorized")
+
+    try:
+        topic = Topic.objects.get(uuid=topic_uuid)
+    except Topic.DoesNotExist:
+        raise HttpError(404, "Topic not found")
+
+    if topic.created_by_id != user.id:
+        raise HttpError(403, "Forbidden")
+
+    webpages = TopicWebpage.objects.filter(topic=topic).order_by("-created_at")
+
+    items = [
+        TopicWebpageResponse(
+            id=webpage.id,
+            title=webpage.title or None,
+            url=webpage.url,
+            description=webpage.description or None,
+            domain=webpage.domain,
+            created_at=make_naive(webpage.created_at),
+        )
+        for webpage in webpages
+    ]
+
+    return TopicWebpageListResponse(total=len(items), items=items)
+
+
+@router.delete("/webpage/{webpage_id}", response={204: None})
+def delete_webpage(request, webpage_id: int):
+    """Remove a webpage link from a topic owned by the user."""
+
+    user = getattr(request, "user", None)
+    if not user or not user.is_authenticated:
+        raise HttpError(401, "Unauthorized")
+
+    try:
+        webpage = TopicWebpage.objects.select_related("topic").get(id=webpage_id)
+    except TopicWebpage.DoesNotExist:
+        raise HttpError(404, "Webpage not found")
+
+    if webpage.topic.created_by_id != user.id:
+        raise HttpError(403, "Forbidden")
+
+    webpage.delete()
+    return 204, None

--- a/semanticnews/topics/utils/documents/tests.py
+++ b/semanticnews/topics/utils/documents/tests.py
@@ -51,3 +51,158 @@ class TopicWebpageTests(TestCase):
         )
 
         self.assertEqual(link.domain, 'example.com')
+
+
+class TopicDocumentAPITests(TestCase):
+    """API tests for creating, listing and deleting topic documents."""
+
+    def setUp(self):
+        super().setUp()
+        self.embedding_patcher = patch(
+            'semanticnews.topics.models.Topic.get_embedding', return_value=[0.0] * 1536
+        )
+        self.embedding_patcher.start()
+        self.addCleanup(self.embedding_patcher.stop)
+
+        self.user = get_user_model().objects.create_user('docuser', 'doc@example.com', 'password')
+        self.client.force_login(self.user)
+        self.topic = Topic.objects.create(title='Doc Topic', created_by=self.user)
+
+    def test_create_document(self):
+        payload = {
+            'topic_uuid': str(self.topic.uuid),
+            'url': 'https://example.com/report.pdf',
+            'title': 'Q1 Report',
+            'description': 'Financial summary',
+        }
+
+        response = self.client.post(
+            '/api/topics/document/create', payload, content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['title'], 'Q1 Report')
+        self.assertEqual(data['document_type'], 'pdf')
+        self.assertEqual(data['domain'], 'example.com')
+        self.assertEqual(TopicDocument.objects.count(), 1)
+        document = TopicDocument.objects.first()
+        self.assertEqual(document.created_by, self.user)
+
+    def test_create_document_requires_authentication(self):
+        self.client.logout()
+        payload = {
+            'topic_uuid': str(self.topic.uuid),
+            'url': 'https://example.com/report.pdf',
+        }
+
+        response = self.client.post(
+            '/api/topics/document/create', payload, content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_list_documents(self):
+        TopicDocument.objects.create(
+            topic=self.topic,
+            url='https://example.com/report.pdf',
+            title='Report',
+            description='',
+            created_by=self.user,
+        )
+        TopicDocument.objects.create(
+            topic=self.topic,
+            url='https://example.com/brief.docx',
+            title='Brief',
+            description='',
+            created_by=self.user,
+        )
+
+        response = self.client.get(f'/api/topics/document/{self.topic.uuid}/list')
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['total'], 2)
+        urls = {item['url'] for item in data['items']}
+        self.assertEqual(urls, {'https://example.com/report.pdf', 'https://example.com/brief.docx'})
+
+    def test_delete_document(self):
+        document = TopicDocument.objects.create(
+            topic=self.topic,
+            url='https://example.com/report.pdf',
+            title='Report',
+            created_by=self.user,
+        )
+
+        response = self.client.delete(f'/api/topics/document/{document.id}')
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(TopicDocument.objects.filter(id=document.id).exists())
+
+
+class TopicWebpageAPITests(TestCase):
+    """API tests for creating, listing and deleting topic webpages."""
+
+    def setUp(self):
+        super().setUp()
+        self.embedding_patcher = patch(
+            'semanticnews.topics.models.Topic.get_embedding', return_value=[0.0] * 1536
+        )
+        self.embedding_patcher.start()
+        self.addCleanup(self.embedding_patcher.stop)
+
+        self.user = get_user_model().objects.create_user('webuser', 'web@example.com', 'password')
+        self.client.force_login(self.user)
+        self.topic = Topic.objects.create(title='Web Topic', created_by=self.user)
+
+    def test_create_webpage(self):
+        payload = {
+            'topic_uuid': str(self.topic.uuid),
+            'url': 'https://example.com/article',
+            'title': 'Interesting article',
+        }
+
+        response = self.client.post(
+            '/api/topics/document/webpage/create', payload, content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['title'], 'Interesting article')
+        self.assertEqual(data['domain'], 'example.com')
+        self.assertEqual(TopicWebpage.objects.count(), 1)
+
+    def test_list_webpages(self):
+        TopicWebpage.objects.create(
+            topic=self.topic,
+            url='https://example.com/a',
+            title='A',
+            created_by=self.user,
+        )
+        TopicWebpage.objects.create(
+            topic=self.topic,
+            url='https://example.com/b',
+            title='B',
+            created_by=self.user,
+        )
+
+        response = self.client.get(f'/api/topics/document/webpage/{self.topic.uuid}/list')
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['total'], 2)
+        titles = {item['title'] for item in data['items']}
+        self.assertEqual(titles, {'A', 'B'})
+
+    def test_delete_webpage(self):
+        webpage = TopicWebpage.objects.create(
+            topic=self.topic,
+            url='https://example.com/a',
+            title='A',
+            created_by=self.user,
+        )
+
+        response = self.client.delete(f'/api/topics/document/webpage/{webpage.id}')
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(TopicWebpage.objects.filter(id=webpage.id).exists())


### PR DESCRIPTION
## Summary
- add a Ninja router for creating, listing, and deleting topic documents and webpages
- expose the new documents router through the topics API
- cover the new endpoints with Django test cases for documents and webpages

## Testing
- python manage.py test semanticnews.topics.utils.documents *(fails: database connection refused in container)*

------
https://chatgpt.com/codex/tasks/task_b_68c94a3597648328beee48e47999090d