### PR TITLE
Add toolbar dropdown for topic documents

### DIFF
--- a/semanticnews/topics/templates/topics/topics_detail_edit.html
+++ b/semanticnews/topics/templates/topics/topics_detail_edit.html
@@ -93,6 +93,7 @@
         <div class="gap-2">
             {% include "topics/recaps/button.html" %}
             {% include "topics/data/button.html" %}
+            {% include "topics/documents/button.html" %}
             {% include "topics/narratives/button.html" %}
             {% include "topics/images/button.html" %}
             {% include "topics/embeds/button.html" %}
@@ -206,6 +207,7 @@
 
 
 {% include "topics/mcps/modal.html" %}
+{% include "topics/documents/modal.html" %}
 {% include "topics/recaps/modal.html" %}
 {% include "topics/data/modal.html" %}
 {% include "topics/data/analyze_modal.html" %}
@@ -228,6 +230,7 @@
     {% include "topics/create_topic_js.html" %}
     {% include "topics/recaps/scripts.html" %}
     {% include "topics/data/scripts.html" %}
+    {% include "topics/documents/scripts.html" %}
     {% include "topics/narratives/scripts.html" %}
     {% include "topics/images/scripts.html" %}
     {% include "topics/embeds/scripts.html" %}

--- a/semanticnews/topics/utils/documents/static/topics/documents/topic_documents.js
+++ b/semanticnews/topics/utils/documents/static/topics/documents/topic_documents.js
@@ -1,0 +1,63 @@
+function handleTopicLinkForm({ formId, modalId, endpoint }) {
+  const form = document.getElementById(formId);
+  if (!form) return;
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+
+    const submitBtn = form.querySelector('button[type="submit"]');
+    if (submitBtn) {
+      submitBtn.disabled = true;
+    }
+
+    const modalEl = document.getElementById(modalId);
+    if (modalEl && window.bootstrap) {
+      const modal = window.bootstrap.Modal.getInstance(modalEl);
+      if (modal) {
+        modal.hide();
+      }
+    }
+
+    const formData = new FormData(form);
+    const payload = Object.fromEntries(formData.entries());
+
+    try {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+      }
+
+      await response.json();
+      window.location.reload();
+    } catch (error) {
+      console.error(error);
+      if (submitBtn) {
+        submitBtn.disabled = false;
+      }
+    }
+  });
+}
+
+function initTopicLinkForms() {
+  const forms = [
+    {
+      formId: 'topicDocumentForm',
+      modalId: 'topicDocumentModal',
+      endpoint: '/api/topics/document/create',
+    },
+    {
+      formId: 'topicWebpageForm',
+      modalId: 'topicWebpageModal',
+      endpoint: '/api/topics/document/webpage/create',
+    },
+  ];
+
+  forms.forEach(handleTopicLinkForm);
+}
+
+document.addEventListener('DOMContentLoaded', initTopicLinkForms);

--- a/semanticnews/topics/utils/documents/templates/topics/documents/button.html
+++ b/semanticnews/topics/utils/documents/templates/topics/documents/button.html
@@ -1,0 +1,32 @@
+{% load i18n %}
+<div class="btn-group" role="group">
+    <button
+        type="button"
+        class="btn btn-outline-secondary btn-sm dropdown-toggle"
+        data-bs-toggle="dropdown"
+        aria-expanded="false"{% if topic.status == 'archived' %} disabled{% endif %}>
+        {% trans "Documents" %}
+    </button>
+    <ul class="dropdown-menu">
+        <li>
+            <button
+                type="button"
+                class="dropdown-item d-flex align-items-center"
+                data-bs-toggle="modal"
+                data-bs-target="#topicDocumentModal"{% if topic.status == 'archived' %} disabled{% endif %}>
+                <i class="bi bi-file-earmark-text me-2"></i>
+                {% trans "Add document" %}
+            </button>
+        </li>
+        <li>
+            <button
+                type="button"
+                class="dropdown-item d-flex align-items-center"
+                data-bs-toggle="modal"
+                data-bs-target="#topicWebpageModal"{% if topic.status == 'archived' %} disabled{% endif %}>
+                <i class="bi bi-globe me-2"></i>
+                {% trans "Add webpage" %}
+            </button>
+        </li>
+    </ul>
+</div>

--- a/semanticnews/topics/utils/documents/templates/topics/documents/modal.html
+++ b/semanticnews/topics/utils/documents/templates/topics/documents/modal.html
@@ -1,0 +1,66 @@
+{% load i18n %}
+<div class="modal fade" id="topicDocumentModal" tabindex="-1" aria-labelledby="topicDocumentModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form id="topicDocumentForm">
+                <div class="modal-header">
+                    <h1 class="modal-title fs-5" id="topicDocumentModalLabel">{% trans "Add document" %}</h1>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans 'Close' %}"></button>
+                </div>
+                <div class="modal-body">
+                    <input type="hidden" name="topic_uuid" value="{{ topic.uuid }}">
+                    <div class="mb-3">
+                        <label for="topicDocumentUrl" class="form-label">{% trans "Document URL" %}</label>
+                        <input type="url" class="form-control" id="topicDocumentUrl" name="url" required placeholder="https://example.com/report.pdf">
+                        <div class="form-text">{% trans "Link to the file or online document you want to reference." %}</div>
+                    </div>
+                    <div class="mb-3">
+                        <label for="topicDocumentTitle" class="form-label">{% trans "Title" %} <span class="text-secondary">{% trans "(optional)" %}</span></label>
+                        <input type="text" class="form-control" id="topicDocumentTitle" name="title" maxlength="255">
+                    </div>
+                    <div class="mb-3">
+                        <label for="topicDocumentDescription" class="form-label">{% trans "Description" %} <span class="text-secondary">{% trans "(optional)" %}</span></label>
+                        <textarea class="form-control" id="topicDocumentDescription" name="description" rows="3"></textarea>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">{% trans "Cancel" %}</button>
+                    <button type="submit" class="btn btn-primary">{% trans "Add" %}</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="topicWebpageModal" tabindex="-1" aria-labelledby="topicWebpageModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form id="topicWebpageForm">
+                <div class="modal-header">
+                    <h1 class="modal-title fs-5" id="topicWebpageModalLabel">{% trans "Add webpage" %}</h1>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans 'Close' %}"></button>
+                </div>
+                <div class="modal-body">
+                    <input type="hidden" name="topic_uuid" value="{{ topic.uuid }}">
+                    <div class="mb-3">
+                        <label for="topicWebpageUrl" class="form-label">{% trans "Webpage URL" %}</label>
+                        <input type="url" class="form-control" id="topicWebpageUrl" name="url" required placeholder="https://example.com/article">
+                        <div class="form-text">{% trans "Link to the article or webpage you want to include." %}</div>
+                    </div>
+                    <div class="mb-3">
+                        <label for="topicWebpageTitle" class="form-label">{% trans "Title" %} <span class="text-secondary">{% trans "(optional)" %}</span></label>
+                        <input type="text" class="form-control" id="topicWebpageTitle" name="title" maxlength="255">
+                    </div>
+                    <div class="mb-3">
+                        <label for="topicWebpageDescription" class="form-label">{% trans "Description" %} <span class="text-secondary">{% trans "(optional)" %}</span></label>
+                        <textarea class="form-control" id="topicWebpageDescription" name="description" rows="3"></textarea>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">{% trans "Cancel" %}</button>
+                    <button type="submit" class="btn btn-primary">{% trans "Add" %}</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/semanticnews/topics/utils/documents/templates/topics/documents/scripts.html
+++ b/semanticnews/topics/utils/documents/templates/topics/documents/scripts.html
@@ -1,0 +1,2 @@
+{% load static %}
+<script src="{% static 'topics/documents/topic_documents.js' %}"></script>


### PR DESCRIPTION
## Summary
- add a documents dropdown button to the topic edit toolbar that links to new document and webpage modals
- provide modal forms for capturing document and webpage URLs with optional metadata
- wire new modal forms to the document API with a dedicated JavaScript helper

## Testing
- python manage.py test semanticnews.topics.utils.documents *(fails: database connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68c94d28d54c83289f6c6977866b33c8