### PR TITLE
Add resources card showing topic documents and webpages

### DIFF
--- a/semanticnews/topics/templates/topics/topics_detail.html
+++ b/semanticnews/topics/templates/topics/topics_detail.html
@@ -196,6 +196,8 @@
 
         {% endif %}
 
+        {% include "topics/documents/card.html" with documents=documents webpages=webpages %}
+
     </div>
 
 </div>

--- a/semanticnews/topics/templates/topics/topics_detail_edit.html
+++ b/semanticnews/topics/templates/topics/topics_detail_edit.html
@@ -201,6 +201,8 @@
 
         {% endif %}
 
+        {% include "topics/documents/card.html" with documents=documents webpages=webpages %}
+
     </div>
 
 </div>

--- a/semanticnews/topics/utils/documents/templates/topics/documents/card.html
+++ b/semanticnews/topics/utils/documents/templates/topics/documents/card.html
@@ -1,0 +1,58 @@
+{% load i18n %}
+<div class="card mt-3" id="topicResourcesCard">
+    <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+            <h6 class="fs-5 mb-0">{% trans "Documents & Webpages" %}</h6>
+        </div>
+        {% if documents or webpages %}
+            {% if documents %}
+                <h6 class="text-uppercase text-secondary small fw-semibold mb-2">{% trans "Documents" %}</h6>
+                {% for document in documents %}
+                    <div class="d-flex align-items-start{% if not forloop.last or webpages %} mb-3{% endif %}">
+                        <i class="bi bi-file-earmark-text text-secondary me-2 mt-1"></i>
+                        <div>
+                            <a href="{{ document.url }}" class="text-info-emphasis text-decoration-none" target="_blank" rel="noopener noreferrer">
+                                {{ document.title|default:document.url }}
+                            </a>
+                            {% if document.description %}
+                                <p class="small text-secondary mb-1">{{ document.description }}</p>
+                            {% endif %}
+                            <div class="small text-secondary">
+                                {{ document.domain }}
+                                {% if document.document_type and document.document_type != 'other' %}
+                                    &middot; {{ document.get_document_type_display }}
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
+                {% endfor %}
+            {% endif %}
+
+            {% if documents and webpages %}
+                <hr class="text-body-secondary opacity-10 my-3">
+            {% endif %}
+
+            {% if webpages %}
+                <h6 class="text-uppercase text-secondary small fw-semibold mb-2">{% trans "Webpages" %}</h6>
+                {% for webpage in webpages %}
+                    <div class="d-flex align-items-start{% if not forloop.last %} mb-3{% endif %}">
+                        <i class="bi bi-globe text-secondary me-2 mt-1"></i>
+                        <div>
+                            <a href="{{ webpage.url }}" class="text-info-emphasis text-decoration-none" target="_blank" rel="noopener noreferrer">
+                                {{ webpage.title|default:webpage.url }}
+                            </a>
+                            {% if webpage.description %}
+                                <p class="small text-secondary mb-1">{{ webpage.description }}</p>
+                            {% endif %}
+                            <div class="small text-secondary">
+                                {{ webpage.domain }}
+                            </div>
+                        </div>
+                    </div>
+                {% endfor %}
+            {% endif %}
+        {% else %}
+            <p class="small text-secondary mb-0">{% trans "No documents or webpages yet." %}</p>
+        {% endif %}
+    </div>
+</div>

--- a/semanticnews/topics/views.py
+++ b/semanticnews/topics/views.py
@@ -21,6 +21,8 @@ def topics_detail(request, slug, username):
             "recaps",
             "narratives",
             "images",
+            "documents",
+            "webpages",
             "youtube_videos",
             "tweets",
             "entity_relations",
@@ -47,6 +49,8 @@ def topics_detail(request, slug, username):
         .order_by("-created_at")
         .first()
     )
+    documents = list(topic.documents.all())
+    webpages = list(topic.webpages.all())
     latest_data = topic.datas.order_by("-created_at").first()
     datas = topic.datas.order_by("-created_at")
     data_insights = topic.data_insights.order_by("-created_at")
@@ -92,6 +96,8 @@ def topics_detail(request, slug, username):
         "data_visualizations": data_visualizations,
         "youtube_video": youtube_video,
         "tweets": tweets,
+        "documents": documents,
+        "webpages": webpages,
     }
     if request.user.is_authenticated:
         context["user_topics"] = Topic.objects.filter(created_by=request.user).exclude(uuid=topic.uuid)
@@ -110,6 +116,8 @@ def topics_detail_edit(request, slug, username):
             "recaps",
             "narratives",
             "images",
+            "documents",
+            "webpages",
             "youtube_videos",
             "tweets",
             "entity_relations",
@@ -139,6 +147,8 @@ def topics_detail_edit(request, slug, username):
         .order_by("-created_at")
         .first()
     )
+    documents = list(topic.documents.all())
+    webpages = list(topic.webpages.all())
     latest_data = topic.datas.order_by("-created_at").first()
     datas = topic.datas.order_by("-created_at")
     data_insights = topic.data_insights.order_by("-created_at")
@@ -184,6 +194,8 @@ def topics_detail_edit(request, slug, username):
         "data_visualizations": data_visualizations,
         "youtube_video": youtube_video,
         "tweets": tweets,
+        "documents": documents,
+        "webpages": webpages,
     }
     if request.user.is_authenticated:
         context["user_topics"] = Topic.objects.filter(created_by=request.user).exclude(


### PR DESCRIPTION
## Summary
- prefetch topic documents and webpages for topic detail views and expose them in the template context
- add a reusable card template that lists attached documents and webpages with metadata and empty state messaging
- render the new resources card beneath the timeline column on both the read-only and edit topic detail pages

## Testing
- python manage.py test semanticnews.topics.utils.documents *(fails: PostgreSQL server is unavailable in the container environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c95b3df3788328a04707832750fd98