### PR TITLE
Enable locale-prefixed URLs

### DIFF
--- a/semanticnews/settings.py
+++ b/semanticnews/settings.py
@@ -61,6 +61,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/semanticnews/tests.py
+++ b/semanticnews/tests.py
@@ -79,3 +79,11 @@ class HomeViewTopicListItemTests(TestCase):
 
         self.assertContains(response, "My recap")
         self.assertContains(response, topic.thumbnail.url)
+
+
+class LocaleRoutingTests(TestCase):
+    def test_homepage_available_with_turkish_prefix(self):
+        response = self.client.get("/tr/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.resolver_match.url_name, "home")


### PR DESCRIPTION
## Summary
- add Django's LocaleMiddleware so language-prefixed URLs resolve correctly
- cover the Turkish home page prefix with a regression test

## Testing
- `python manage.py test` *(fails: PostgreSQL server not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cd18d9322883289df48a61cf109f18