### PR TITLE
Make agenda initial migration non-atomic

### DIFF
--- a/semanticnews/agenda/migrations/0001_initial.py
+++ b/semanticnews/agenda/migrations/0001_initial.py
@@ -13,6 +13,11 @@ class Migration(migrations.Migration):
 
     initial = True
 
+    # Creating the "vector" extension must happen outside of a transaction;
+    # otherwise PostgreSQL can't see the new type when the model is created
+    # later in this migration.
+    atomic = False
+
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]


### PR DESCRIPTION
## Summary
- make the agenda initial migration non-atomic so the vector extension is created outside a transaction

## Testing
- python -m compileall semanticnews/agenda/migrations/0001_initial.py

------
https://chatgpt.com/codex/tasks/task_b_68ce74fe62c0832888ccfa5cacffe758