### PR TITLE
Improve default language prompt phrasing

### DIFF
--- a/semanticnews/agenda/api.py
+++ b/semanticnews/agenda/api.py
@@ -6,6 +6,7 @@ from django.db.models import F, Value
 from ninja import NinjaAPI, Schema
 from ninja.errors import HttpError
 from semanticnews.openai import OpenAI
+from semanticnews.prompting import append_default_language_instruction
 from pgvector.django import CosineDistance
 
 from .models import Event, Source, Category
@@ -193,6 +194,7 @@ def validate_event(request, payload: EventValidationRequest):
         f"Does the following describe an event or incident that occurred on {payload.date:%Y-%m-%d}?\n"
         f"Title: {payload.title}\n"
     )
+    prompt = append_default_language_instruction(prompt)
 
     with OpenAI() as client:
         response = client.responses.parse(
@@ -413,6 +415,7 @@ def suggest_events(
         "State the core fact directly and neutrally avoid newspaper-style headlines. "
         "For each event, include a few source URLs as citations. "
     )
+    prompt = append_default_language_instruction(prompt)
 
     if exclude:
         excluded_events = "\n".join(

--- a/semanticnews/agenda/tests.py
+++ b/semanticnews/agenda/tests.py
@@ -4,6 +4,7 @@ import json
 from django.test import SimpleTestCase, TestCase
 from django.contrib.auth import get_user_model
 
+from semanticnews.prompting import get_default_language_instruction
 from .api import EventValidationResponse, AgendaEventList, AgendaEventResponse
 from .models import Event
 
@@ -56,6 +57,7 @@ class ValidateEventTests(SimpleTestCase):
             kwargs["response_format"]["json_schema"]["schema"],
             EventValidationResponse.model_json_schema(),
         )
+        self.assertIn(get_default_language_instruction(), kwargs["input"])
 
 
 class SuggestEventsTests(SimpleTestCase):
@@ -97,6 +99,8 @@ class SuggestEventsTests(SimpleTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), mock_events)
         mock_client.responses.parse.assert_called_once()
+        _, kwargs = mock_client.responses.parse.call_args
+        self.assertIn(get_default_language_instruction(), kwargs["input"])
 
     @patch("semanticnews.agenda.api.OpenAI")
     def test_suggest_events_excludes_events(self, mock_openai):
@@ -160,6 +164,7 @@ class SuggestEventsTests(SimpleTestCase):
         _, kwargs = mock_client.responses.parse.call_args
         self.assertIn("Do not include the following events", kwargs["input"])
         self.assertIn("Event A on 2024-06-01", kwargs["input"])
+        self.assertIn(get_default_language_instruction(), kwargs["input"])
 
     @patch("semanticnews.agenda.api.OpenAI")
     def test_suggest_events_post_accepts_exclude_list(self, mock_openai):

--- a/semanticnews/prompting.py
+++ b/semanticnews/prompting.py
@@ -1,0 +1,82 @@
+"""Shared prompt utilities for Semantic News AI interactions."""
+
+from collections.abc import Iterable
+
+from django.conf import settings
+from django.utils.translation import get_language_info
+
+
+_DEFAULT_LANGUAGE_CODE = "en"
+_DEFAULT_LANGUAGE_NAME = "English"
+
+
+def get_default_language_instruction() -> str:
+    """Return the instruction to respond in the configured default language."""
+
+    language_name = _DEFAULT_LANGUAGE_NAME
+
+    if getattr(settings, "configured", False):
+        language_code = getattr(settings, "LANGUAGE_CODE", _DEFAULT_LANGUAGE_CODE)
+        resolved_name = _resolve_language_name(language_code, getattr(settings, "LANGUAGES", ()))
+        if resolved_name:
+            language_name = resolved_name
+
+    return f"Respond in {language_name}."
+
+
+def append_default_language_instruction(prompt: str) -> str:
+    """Append the default language instruction to a prompt.
+
+    Ensures the instruction appears on a new line even if the prompt already
+    ends with other text.
+    """
+
+    instruction = get_default_language_instruction()
+    if prompt.endswith("\n"):
+        return prompt + instruction
+    return prompt + "\n" + instruction
+
+
+def _resolve_language_name(language_code: str, languages: Iterable[tuple[str, str]]) -> str | None:
+    """Return a human-readable language name for ``language_code``."""
+
+    for candidate in _language_code_candidates(language_code):
+        name = _lookup_language_name(candidate, languages)
+        if name:
+            return name
+
+    for candidate in _language_code_candidates(language_code):
+        try:
+            info = get_language_info(candidate)
+        except KeyError:
+            continue
+
+        name = info.get("name_local") or info.get("name")
+        if name:
+            return name
+
+    return None
+
+
+def _lookup_language_name(language_code: str, languages: Iterable[tuple[str, str]]) -> str | None:
+    normalized = language_code.lower()
+    for configured_code, configured_name in languages:
+        if str(configured_code).lower() == normalized:
+            return str(configured_name)
+    return None
+
+
+def _language_code_candidates(language_code: str) -> list[str]:
+    normalized = language_code.replace("_", "-")
+    candidates: list[str] = []
+
+    def _add(code: str) -> None:
+        if code and code not in candidates:
+            candidates.append(code)
+
+    _add(language_code)
+    _add(normalized)
+    if "-" in normalized:
+        _add(normalized.split("-", 1)[0])
+
+    return candidates

--- a/semanticnews/tests.py
+++ b/semanticnews/tests.py
@@ -3,14 +3,44 @@ import shutil
 import tempfile
 
 from django.conf import settings
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase, override_settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
+from semanticnews.prompting import get_default_language_instruction
 from semanticnews.topics.models import Topic
 from semanticnews.agenda.models import Event
 from semanticnews.topics.utils.images.models import TopicImage
 from semanticnews.topics.utils.recaps.models import TopicRecap
+
+
+class PromptingInstructionTests(SimpleTestCase):
+    def test_default_instruction_uses_english(self):
+        self.assertEqual(
+            get_default_language_instruction(),
+            "Respond in English.",
+        )
+
+    @override_settings(LANGUAGE_CODE="tr", LANGUAGES=[("tr", "Turkish")])
+    def test_instruction_uses_configured_language_name(self):
+        self.assertEqual(
+            get_default_language_instruction(),
+            "Respond in Turkish.",
+        )
+
+    @override_settings(LANGUAGE_CODE="fr", LANGUAGES=[("en", "English")])
+    def test_instruction_falls_back_to_language_info(self):
+        self.assertEqual(
+            get_default_language_instruction(),
+            "Respond in French.",
+        )
+
+    @override_settings(LANGUAGE_CODE="pt-br", LANGUAGES=[("pt", "Portuguese")])
+    def test_instruction_supports_language_variants(self):
+        self.assertEqual(
+            get_default_language_instruction(),
+            "Respond in Portuguese.",
+        )
 
 
 class SearchViewTests(TestCase):

--- a/semanticnews/topics/api.py
+++ b/semanticnews/topics/api.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 
 from semanticnews.agenda.models import Event
 from semanticnews.openai import OpenAI
+from semanticnews.prompting import append_default_language_instruction
 
 from .models import Topic
 from .utils.timeline.models import TopicEvent
@@ -341,6 +342,7 @@ def suggest_topics(about: str, limit: int = 3) -> List[str]:
         f"Avoid overly specific or literal restatements of the subject. "
         f"Make the {limit} suggestions vary in scope, but none too specific. "
     )
+    prompt = append_default_language_instruction(prompt)
 
     with OpenAI() as client:
         response = client.responses.parse(

--- a/semanticnews/topics/test_api_suggest_topics.py
+++ b/semanticnews/topics/test_api_suggest_topics.py
@@ -2,6 +2,8 @@ from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase
 
+from semanticnews.prompting import get_default_language_instruction
+
 
 class SuggestTopicsAPITests(SimpleTestCase):
     """Tests for the topics suggestion API endpoint."""
@@ -19,6 +21,8 @@ class SuggestTopicsAPITests(SimpleTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), ["Topic A", "Topic B"])
         mock_client.responses.parse.assert_called_once()
+        _, kwargs = mock_client.responses.parse.call_args
+        self.assertIn(get_default_language_instruction(), kwargs["input"])
 
     @patch("semanticnews.topics.api.OpenAI")
     def test_suggest_topics_post(self, mock_openai):
@@ -38,3 +42,5 @@ class SuggestTopicsAPITests(SimpleTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), ["Topic X"])
         mock_client.responses.parse.assert_called_once()
+        _, kwargs = mock_client.responses.parse.call_args
+        self.assertIn(get_default_language_instruction(), kwargs["input"])

--- a/semanticnews/topics/tests.py
+++ b/semanticnews/topics/tests.py
@@ -15,6 +15,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 
 from semanticnews.agenda.models import Event
 from semanticnews.contents.models import Content
+from semanticnews.prompting import get_default_language_instruction
 
 from .models import Topic, TopicContent, TopicKeyword
 from .utils.timeline.models import TopicEvent
@@ -310,6 +311,7 @@ class AnalyzeDataAPITests(TestCase):
 
         args, kwargs = mock_client.responses.parse.call_args
         self.assertIn("Focus on anomalies", kwargs["input"])
+        self.assertIn(get_default_language_instruction(), kwargs["input"])
 
     @patch("semanticnews.topics.utils.data.api.OpenAI")
     @patch(

--- a/semanticnews/topics/utils/data/tests.py
+++ b/semanticnews/topics/utils/data/tests.py
@@ -2,6 +2,7 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from unittest.mock import MagicMock, patch
 
+from semanticnews.prompting import get_default_language_instruction
 from semanticnews.topics.models import Topic
 
 
@@ -49,6 +50,8 @@ class TopicDataSearchAPITests(TestCase):
         )
         self.assertNotIn("explanation", response.json())
         mock_client.responses.parse.assert_called_once()
+        _, kwargs = mock_client.responses.parse.call_args
+        self.assertIn(get_default_language_instruction(), kwargs["input"])
 
     @patch("semanticnews.topics.utils.data.api.OpenAI")
     def test_search_data_returns_explanation_when_needed(self, mock_openai):
@@ -90,6 +93,8 @@ class TopicDataSearchAPITests(TestCase):
             },
         )
         mock_client.responses.parse.assert_called_once()
+        _, kwargs = mock_client.responses.parse.call_args
+        self.assertIn(get_default_language_instruction(), kwargs["input"])
 
     def test_search_requires_authentication(self):
         User = get_user_model()

--- a/semanticnews/topics/utils/images/api.py
+++ b/semanticnews/topics/utils/images/api.py
@@ -12,6 +12,7 @@ from django.core.files.base import ContentFile
 from ...models import Topic
 from .models import TopicImage
 from ....openai import OpenAI
+from semanticnews.prompting import append_default_language_instruction
 
 router = Router()
 
@@ -55,6 +56,7 @@ def create_image(request, payload: TopicImageCreateRequest):
     elif chosen_style == "illustration":
         style_hint = "- clean vector illustration\n"
 
+    context = topic.build_context()
     prompt = (
         "Create an illustration based on the abstract description of the content in the news item.\n"
         "- flat-illustration style, muted teal/terracotta palette and simple shapes\n"
@@ -62,8 +64,9 @@ def create_image(request, payload: TopicImageCreateRequest):
         "- the image’s job is to cue, not tell the whole story\n"
         "- symbolic, not partisan without extremist branding\n"
         f"{style_hint}\n"
-        f"{topic.build_context()}"
     )
+    prompt = append_default_language_instruction(prompt)
+    prompt += f"\n\n{context}"
 
     topic_image = TopicImage.objects.create(topic=topic)
     try:

--- a/semanticnews/topics/utils/narratives/api.py
+++ b/semanticnews/topics/utils/narratives/api.py
@@ -8,6 +8,7 @@ from ninja.errors import HttpError
 from ...models import Topic
 from .models import TopicNarrative
 from ....openai import OpenAI
+from semanticnews.prompting import append_default_language_instruction
 
 router = Router()
 
@@ -55,8 +56,9 @@ def create_narrative(request, payload: TopicNarrativeCreateRequest):
         "Write a detailed narrative that explains the full context and connections between them. "
         "Respond in Markdown and highlight key entities by making them **bold**. "
         "Use paragraphs where appropriate. "
-        f"\n\n{content_md}"
     )
+    prompt = append_default_language_instruction(prompt)
+    prompt += f"\n\n{content_md}"
 
     narrative_obj = TopicNarrative.objects.create(topic=topic, narrative="")
     try:

--- a/semanticnews/topics/utils/recaps/api.py
+++ b/semanticnews/topics/utils/recaps/api.py
@@ -8,6 +8,7 @@ from ninja.errors import HttpError
 from ...models import Topic
 from .models import TopicRecap
 from ....openai import OpenAI
+from semanticnews.prompting import append_default_language_instruction
 
 router = Router()
 
@@ -66,8 +67,9 @@ def create_recap(request, payload: TopicRecapCreateRequest):
         " Provide a concise, coherent recap summarizing the essential narrative and main points. "
         "Respond in Markdown and highlight key entities by making them **bold**. "
         "Give paragraph breaks where appropriate. Do not use any other formatting such as lists, titles, etc. "
-        f"\n\n{content_md}"
     )
+    prompt = append_default_language_instruction(prompt)
+    prompt += f"\n\n{content_md}"
 
     try:
         with OpenAI() as client:

--- a/semanticnews/topics/utils/relations/api.py
+++ b/semanticnews/topics/utils/relations/api.py
@@ -7,6 +7,7 @@ from django.utils.timezone import make_naive
 from ...models import Topic
 from .models import TopicEntityRelation
 from ....openai import OpenAI
+from semanticnews.prompting import append_default_language_instruction
 
 router = Router()
 
@@ -61,8 +62,9 @@ def extract_entity_relations(request, payload: TopicEntityRelationCreateRequest)
         "Identify the key entities and the relations between them. "
         "Respond with a JSON object containing a list 'relations' where each item has "
         "'source', 'relation', and 'target' fields. "
-        f"\n\n{content_md}"
     )
+    prompt = append_default_language_instruction(prompt)
+    prompt += f"\n\n{content_md}"
 
     relation_obj = TopicEntityRelation.objects.create(topic=topic, relations=[])
     try:

--- a/semanticnews/topics/utils/timeline/api.py
+++ b/semanticnews/topics/utils/timeline/api.py
@@ -12,6 +12,7 @@ from ...models import Topic
 from ....agenda.models import Category, Event, Source
 from .models import TopicEvent
 from ....openai import OpenAI
+from semanticnews.prompting import append_default_language_instruction
 
 
 router = Router()
@@ -145,6 +146,7 @@ def suggest_topic_events(request, payload: TimelineSuggestRequest):
         "State the core fact directly and neutrally. "
         "For each event, include a few source URLs as citations."
     )
+    prompt = append_default_language_instruction(prompt)
 
     context = topic.build_context()
     if context:


### PR DESCRIPTION
## Summary
- update the shared prompt helper to emit a natural-language instruction like "Respond in English."
- add utilities to resolve human-readable language names from Django settings or built-in locale metadata
- cover the prompt helper with tests for default, configured, and variant language codes

## Testing
- `pytest semanticnews/agenda/tests.py semanticnews/topics/test_api_suggest_topics.py semanticnews/topics/utils/data/tests.py semanticnews/topics/tests.py` *(fails: Django settings/apps are not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d2264150408328941bfb7ed54a82de