### PR TITLE
Add list views for topics, events, and users

### DIFF
--- a/semanticnews/agenda/templates/agenda/event_recent_list.html
+++ b/semanticnews/agenda/templates/agenda/event_recent_list.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block content %}
+<div class="container py-4">
+    <div class="row">
+        <div class="col-12 col-lg-8 mx-auto">
+            <h1 class="fs-3 mb-3">{% trans "Latest events" %}</h1>
+
+            {% if events %}
+                {% for event in events %}
+                    {% include "agenda/event_list_item.html" %}
+                {% endfor %}
+            {% else %}
+                <p class="text-secondary">{% trans "No events have been published yet." %}</p>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/semanticnews/agenda/views.py
+++ b/semanticnews/agenda/views.py
@@ -14,6 +14,25 @@ from semanticnews.topics.models import Topic
 DISTANCE_THRESHOLD = 1
 
 
+def recent_event_list(request):
+    """Display the most recently updated published events."""
+
+    events = (
+        Event.objects.filter(status="published")
+        .select_related("created_by")
+        .prefetch_related("categories", "sources")
+        .order_by("-updated_at", "-date", "-created_at")
+    )
+
+    context = {"events": events}
+    if request.user.is_authenticated:
+        context["user_topics"] = Topic.objects.filter(created_by=request.user).order_by(
+            "-updated_at"
+        )
+
+    return render(request, "agenda/event_recent_list.html", context)
+
+
 def event_detail(request, year, month, day, slug):
     obj = get_object_or_404(
         Event.objects.prefetch_related(

--- a/semanticnews/profiles/templates/profiles/user_list.html
+++ b/semanticnews/profiles/templates/profiles/user_list.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block content %}
+<div class="container py-4">
+    <div class="row">
+        <div class="col-12 col-lg-8 mx-auto">
+            <h1 class="fs-3 mb-3">{% trans "Community activity" %}</h1>
+
+            {% if users %}
+                <ul class="list-unstyled mb-0">
+                    {% for person in users %}
+                        <li class="border-bottom pb-3 mb-3">
+                            <h2 class="fs-5 mb-1">
+                                <a class="text-decoration-none" href="{% url 'user_profile' username=person.username %}">
+                                    {{ person.get_full_name|default:person.username }}
+                                </a>
+                            </h2>
+                            <p class="small text-secondary mb-1">
+                                <span class="me-2">
+                                    {% blocktrans count topic_count=person.topics_count %}
+                                        {{ topic_count }} topic
+                                    {% plural %}
+                                        {{ topic_count }} topics
+                                    {% endblocktrans %}
+                                </span>
+                                <span>
+                                    {% blocktrans count event_count=person.events_count %}
+                                        {{ event_count }} event
+                                    {% plural %}
+                                        {{ event_count }} events
+                                    {% endblocktrans %}
+                                </span>
+                            </p>
+                            <p class="small text-secondary mb-0">
+                                {% blocktrans with timesince=person.last_activity|timesince %}
+                                    Active {{ timesince }} ago
+                                {% endblocktrans %}
+                            </p>
+                        </li>
+                    {% endfor %}
+                </ul>
+            {% else %}
+                <p class="text-secondary">{% trans "No users have contributed yet." %}</p>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/semanticnews/profiles/tests.py
+++ b/semanticnews/profiles/tests.py
@@ -1,3 +1,40 @@
-from django.test import TestCase
+from datetime import timedelta
 
-# Create your tests here.
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils import timezone
+
+from semanticnews.agenda.models import Event
+from semanticnews.topics.models import Topic
+
+class UserListViewTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.alice = User.objects.create_user("alice", "alice@example.com", "password")
+        self.bob = User.objects.create_user("bob", "bob@example.com", "password", is_active=False)
+
+    def test_lists_active_users(self):
+        Topic.objects.create(title="Alice Topic", created_by=self.alice, status="published")
+
+        response = self.client.get(reverse("user_list"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.alice.username)
+        self.assertNotContains(response, self.bob.username)
+
+    def test_orders_users_by_recent_activity(self):
+        Topic.objects.create(title="Old", created_by=self.alice, status="published")
+        Topic.objects.create(title="New", created_by=self.alice, status="published")
+        # Simulate older activity for Alice
+        Topic.objects.filter(created_by=self.alice).update(
+            updated_at=timezone.now() - timedelta(days=2)
+        )
+
+        carol = get_user_model().objects.create_user("carol", "carol@example.com", "password")
+        Event.objects.create(title="Fresh Event", date="2024-01-01", status="published", created_by=carol)
+
+        response = self.client.get(reverse("user_list"))
+
+        users = list(response.context["users"])
+        self.assertEqual(users[0].username, "carol")

--- a/semanticnews/topics/templates/topics/topics_list.html
+++ b/semanticnews/topics/templates/topics/topics_list.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block content %}
+<div class="container py-4">
+    <div class="row">
+        <div class="col-12 col-lg-8 mx-auto">
+            <div class="d-flex align-items-center justify-content-between mb-3">
+                <h1 class="fs-3 mb-0">{% trans "Latest topics" %}</h1>
+                {% if user.is_authenticated %}
+                    <button class="btn btn-sm btn-outline-secondary add-topic-btn" title="{% trans 'Add topic' %}">
+                        <i class="bi bi-plus-lg"></i>
+                    </button>
+                {% endif %}
+            </div>
+
+            {% if topics %}
+                {% for topic in topics %}
+                    {% include "topics/topics_list_item.html" %}
+                {% endfor %}
+            {% else %}
+                <p class="text-secondary">{% trans "No topics have been published yet." %}</p>
+            {% endif %}
+        </div>
+    </div>
+</div>
+
+{% include "topics/create_topic_modal.html" %}
+{% endblock %}
+
+{% block extra_js %}
+    {{ block.super }}
+    {% include "topics/create_topic_js.html" %}
+{% endblock %}

--- a/semanticnews/topics/views.py
+++ b/semanticnews/topics/views.py
@@ -9,6 +9,24 @@ from .models import Topic
 from .utils.timeline.models import TopicEvent
 from .utils.mcps.models import MCPServer
 
+def topics_list(request):
+    """Display the most recently updated published topics."""
+
+    topics = (
+        Topic.objects.filter(status="published")
+        .select_related("created_by")
+        .prefetch_related("recaps", "images")
+        .order_by("-updated_at", "-created_at")
+    )
+
+    context = {"topics": topics}
+    if request.user.is_authenticated:
+        context["user_topics"] = Topic.objects.filter(created_by=request.user).order_by(
+            "-updated_at"
+        )
+
+    return render(request, "topics/topics_list.html", context)
+
 
 def topics_detail(request, slug, username):
     topic = get_object_or_404(

--- a/semanticnews/urls.py
+++ b/semanticnews/urls.py
@@ -27,6 +27,9 @@ urlpatterns = [
 urlpatterns += i18n_patterns(
     path('', core_views.home, name='home'),
     path('search/', core_views.search_results, name='search_results'),
+    path('topics/', topics_views.topics_list, name='topics_list'),
+    path('events/', agenda_views.recent_event_list, name='events_recent_list'),
+    path('users/', profiles_views.user_list, name='user_list'),
 
     re_path(
         r'^(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})/(?P<slug>[-\w]+)/$',


### PR DESCRIPTION
## Summary
- add dedicated list views and templates for recently updated topics and events
- expose a community activity page that ranks active users by their latest contributions
- cover the new pages with view tests to ensure filtering and context data

## Testing
- `python manage.py test` *(fails: database server for tests is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d44b70b4c48328853cd4b799681bb5