### PR TITLE
Add AI suggestions to topic title modal

### DIFF
--- a/semanticnews/topics/templates/topics/topic_title_modal.html
+++ b/semanticnews/topics/templates/topics/topic_title_modal.html
@@ -21,8 +21,27 @@
           >
           <div class="form-text">{% trans "Leave blank to keep the topic untitled." %}</div>
         </div>
+        <div
+          class="mb-3 d-none"
+          id="topicTitleSuggestions"
+          data-no-results-message="{% trans "No suggestions available yet. Try refining your description." %}"
+        >
+          <p class="form-text mb-2">{% trans "Select a suggestion to populate the title." %}</p>
+          <div class="list-group" id="topicTitleSuggestionsList"></div>
+        </div>
       </div>
       <div class="modal-footer">
+        <button
+          type="button"
+          class="btn btn-outline-secondary me-auto"
+          id="topicTitleSuggestBtn"
+          data-default-label="{% trans "Suggest" %}"
+          data-loading-label="{% trans "Suggesting" %}…"
+          data-empty-input-message="{% trans "Describe what the topic is about to get suggestions." %}"
+          data-generic-error-message="{% trans "Unable to fetch suggestions." %}"
+        >
+          {% trans "Suggest" %}
+        </button>
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Cancel" %}</button>
         <button type="submit" class="btn btn-primary">{% trans "Save" %}</button>
       </div>


### PR DESCRIPTION
## Summary
- add a suggestion button and localized helper text to the topic title modal
- fetch AI-powered title suggestions and allow users to apply them to the input field

## Testing
- Not run (front-end change only)


------
https://chatgpt.com/codex/tasks/task_b_68d666f443748328a72ea2b6e1a920af