### PR TITLE
Fix timeline suggestions association

### DIFF
--- a/semanticnews/topics/utils/timeline/templates/topics/timeline/modal.html
+++ b/semanticnews/topics/utils/timeline/templates/topics/timeline/modal.html
@@ -77,7 +77,7 @@
               <p>{% trans "Loading suggestions..." %}</p>
             </div>
             <div class="modal-footer px-0">
-              <button type="button" class="btn btn-primary" id="publishSelectedEventsBtn" disabled>{% trans "Publish selected" %}</button>
+              <button type="button" class="btn btn-primary" id="addSuggestedEventsBtn" disabled>{% trans "Add selected" %}</button>
               <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Close" %}</button>
             </div>
           </div>

--- a/semanticnews/topics/utils/timeline/tests.py
+++ b/semanticnews/topics/utils/timeline/tests.py
@@ -1,0 +1,42 @@
+import json
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from semanticnews.agenda.models import Event
+from semanticnews.topics.models import Topic
+from semanticnews.topics.utils.timeline.models import TopicEvent
+
+
+class TimelineCreateAPITests(TestCase):
+    """Tests for relating AI-suggested events to a topic via the API."""
+
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user("user", "user@example.com", "password")
+        self.client.force_login(self.user)
+
+    def test_links_selected_events_to_topic(self):
+        topic = Topic.objects.create(title="My Topic", created_by=self.user)
+        event = Event.objects.create(title="Suggested", date="2024-01-01")
+
+        payload = {
+            "topic_uuid": str(topic.uuid),
+            "event_uuids": [str(event.uuid)],
+        }
+        response = self.client.post(
+            "/api/topics/timeline/create",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["uuid"], str(event.uuid))
+
+        topic.refresh_from_db()
+        self.assertTrue(topic.events.filter(pk=event.pk).exists())
+        topic_event = TopicEvent.objects.get(topic=topic, event=event)
+        self.assertEqual(topic_event.source, "agent")
+        self.assertEqual(topic_event.created_by, self.user)


### PR DESCRIPTION
## Summary
- rename the suggested timeline events action to "Add selected" in the modal
- ensure the timeline modal only enables the add button when items are checked and send event UUIDs to the create API
- add a regression test that verifies the timeline create endpoint links selected events to the topic

## Testing
- python manage.py test semanticnews.topics.utils.timeline.tests *(fails: database connection refused in container environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d66ddf96648328b18e50e2e724588e