### PR TITLE
Use topic UUID for edit routes

### DIFF
--- a/semanticnews/topics/templates/topics/topics_detail.html
+++ b/semanticnews/topics/templates/topics/topics_detail.html
@@ -98,7 +98,7 @@
                     {% trans "Edit" %}
                 </a>
             {% else %}
-                <a class="btn btn-outline-primary btn-sm align-self-start" href="{% url 'topics_detail_edit' slug=topic.slug username=topic.created_by.username %}">
+                <a class="btn btn-outline-primary btn-sm align-self-start" href="{% url 'topics_detail_edit' topic_uuid=topic.uuid username=topic.created_by.username %}">
                     {% trans "Edit" %}
                 </a>
             {% endif %}

--- a/semanticnews/topics/templates/topics/topics_detail_edit.html
+++ b/semanticnews/topics/templates/topics/topics_detail_edit.html
@@ -15,7 +15,7 @@
 
     <div
         data-topic-uuid="{{ topic.uuid }}"
-        data-topic-slug="{{ topic.slug|default:topic.uuid }}"
+        data-topic-slug="{{ topic.slug|default:'' }}"
         data-topic-title="{{ topic.title|default_if_none:'' }}"
     >
 

--- a/semanticnews/topics/utils/embeds/tests.py
+++ b/semanticnews/topics/utils/embeds/tests.py
@@ -176,7 +176,7 @@ class TopicVideoEmbedDisplayTests(TestCase):
         self.client.force_login(self.user)
         url = reverse(
             'topics_detail_edit',
-            kwargs={'username': self.user.username, 'slug': self.topic.slug},
+            kwargs={'username': self.user.username, 'topic_uuid': str(self.topic.uuid)},
         )
         response = self.client.get(url)
         self.assertContains(response, 'youtube.com/embed/vid123')

--- a/semanticnews/topics/views.py
+++ b/semanticnews/topics/views.py
@@ -23,10 +23,6 @@ def topic_create(request):
         topic.title = title
         topic.save(update_fields=["title"])
 
-    if not topic.slug:
-        Topic.objects.filter(pk=topic.pk).update(slug=str(topic.uuid))
-        topic.slug = str(topic.uuid)
-
     if event_uuid:
         try:
             event = Event.objects.get(uuid=event_uuid)
@@ -41,7 +37,7 @@ def topic_create(request):
 
     return redirect(
         "topics_detail_edit",
-        slug=topic.slug,
+        topic_uuid=str(topic.uuid),
         username=request.user.username,
     )
 
@@ -137,7 +133,7 @@ def topics_detail(request, slug, username):
 
 
 @login_required
-def topics_detail_edit(request, slug, username):
+def topics_detail_edit(request, topic_uuid, username):
     topic = get_object_or_404(
         Topic.objects.prefetch_related(
             "events",
@@ -153,7 +149,7 @@ def topics_detail_edit(request, slug, username):
             "data_insights__sources",
             "data_visualizations__insight",
         ),
-        slug=slug,
+        uuid=topic_uuid,
         created_by__username=username,
     )
 

--- a/semanticnews/urls.py
+++ b/semanticnews/urls.py
@@ -56,7 +56,7 @@ urlpatterns += i18n_patterns(
     path('@<slug:username>/<slug:slug>/add-event/<uuid:event_uuid>/', topics_views.topic_add_event, name='topics_add_event'),
     path('@<slug:username>/<slug:slug>/remove-event/<uuid:event_uuid>/', topics_views.topic_remove_event, name='topics_remove_event'),
     path('@<slug:username>/<slug:slug>/clone/', topics_views.topic_clone, name='topics_clone'),
-    path('@<slug:username>/<slug:slug>/edit/', topics_views.topics_detail_edit, name='topics_detail_edit'),
+    path('@<slug:username>/<uuid:topic_uuid>/edit/', topics_views.topics_detail_edit, name='topics_detail_edit'),
     path('@<slug:username>/<slug:slug>/', topics_views.topics_detail, name='topics_detail'),
 
     path('@<slug:username>/', profiles_views.user_profile, name='user_profile'),


### PR DESCRIPTION
## Summary
- switch the topic edit URL and view to use a UUID parameter instead of the slug
- remove slug fallback logic and update the API, templates, and tests to align with the UUID-based edit flow

## Testing
- python manage.py test semanticnews.topics.tests semanticnews.topics.utils.embeds.tests *(fails: PostgreSQL not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d77363a1548328a428f6920666e96a