### PR TITLE
Add configurable default AI model setting

### DIFF
--- a/semanticnews/agenda/api.py
+++ b/semanticnews/agenda/api.py
@@ -2,6 +2,7 @@ from datetime import date
 from typing import List, Optional
 import json
 
+from django.conf import settings
 from django.db.models import F, Value
 from ninja import NinjaAPI, Schema
 from ninja.errors import HttpError
@@ -198,7 +199,7 @@ def validate_event(request, payload: EventValidationRequest):
 
     with OpenAI() as client:
         response = client.responses.parse(
-            model="gpt-5",
+            model=settings.DEFAULT_AI_MODEL,
             tools=[{"type": "web_search_preview"}],
             input=prompt,
             text_format=EventValidationResponse,
@@ -430,7 +431,7 @@ def suggest_events(
 
     with OpenAI() as client:
         response = client.responses.parse(
-            model="gpt-5",
+            model=settings.DEFAULT_AI_MODEL,
             tools=[{"type": "web_search_preview"}],
             input=prompt,
             text_format=AgendaEventList,

--- a/semanticnews/settings/base.py
+++ b/semanticnews/settings/base.py
@@ -196,6 +196,9 @@ _static_dirs = [BASE_DIR / 'static', PACKAGE_ROOT / 'static']
 STATICFILES_DIRS = tuple(str(path) for path in _static_dirs if path.exists())
 
 
+# AI / LLM configuration
+DEFAULT_AI_MODEL = os.getenv("DEFAULT_AI_MODEL", "gpt-5")
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 

--- a/semanticnews/topics/api.py
+++ b/semanticnews/topics/api.py
@@ -2,6 +2,7 @@ from ninja import NinjaAPI, Schema
 from ninja.errors import HttpError
 from typing import Optional, List, Literal
 from datetime import datetime
+from django.conf import settings
 from django.utils import timezone
 from django.urls import reverse
 
@@ -395,7 +396,7 @@ def suggest_topics(about: str, limit: int = 3) -> List[str]:
 
     with OpenAI() as client:
         response = client.responses.parse(
-            model="gpt-5",
+            model=settings.DEFAULT_AI_MODEL,
             input=prompt,
             text_format=TopicSuggestionList,
         )

--- a/semanticnews/topics/utils/data/api.py
+++ b/semanticnews/topics/utils/data/api.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from django.conf import settings
 from ninja import Router, Schema
 from ninja.errors import HttpError
 from pydantic import ConfigDict
@@ -127,7 +128,7 @@ def fetch_data(request, payload: TopicDataFetchRequest):
 
     with OpenAI() as client:
         response = client.responses.parse(
-            model="gpt-5",
+            model=settings.DEFAULT_AI_MODEL,
             input=prompt,
             tools=[{"type": "web_search_preview"}],
             text_format=_TopicDataResponse,
@@ -162,7 +163,7 @@ def search_data(request, payload: TopicDataSearchRequest):
 
     with OpenAI() as client:
         response = client.responses.parse(
-            model="gpt-5",
+            model=settings.DEFAULT_AI_MODEL,
             input=prompt,
             tools=[{"type": "web_search_preview"}],
             text_format=_TopicDataSearchResponse,

--- a/semanticnews/topics/utils/narratives/api.py
+++ b/semanticnews/topics/utils/narratives/api.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from typing import List, Optional
 
+from django.conf import settings
 from django.utils.timezone import make_naive
 from ninja import Router, Schema
 from ninja.errors import HttpError
@@ -64,7 +65,7 @@ def create_narrative(request, payload: TopicNarrativeCreateRequest):
     try:
         with OpenAI() as client:
             response = client.responses.parse(
-                model="gpt-5",
+                model=settings.DEFAULT_AI_MODEL,
                 input=prompt,
                 text_format=_TopicNarrativeResponse,
             )

--- a/semanticnews/topics/utils/recaps/api.py
+++ b/semanticnews/topics/utils/recaps/api.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from typing import Optional, Literal, List
 
+from django.conf import settings
 from django.utils.timezone import make_naive
 from ninja import Router, Schema
 from ninja.errors import HttpError
@@ -74,7 +75,7 @@ def create_recap(request, payload: TopicRecapCreateRequest):
     try:
         with OpenAI() as client:
             response = client.responses.parse(
-                model="gpt-5",
+                model=settings.DEFAULT_AI_MODEL,
                 input=prompt,
                 text_format=_TopicRecapResponse,
             )

--- a/semanticnews/topics/utils/relations/api.py
+++ b/semanticnews/topics/utils/relations/api.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 from datetime import datetime
 
+from django.conf import settings
 from ninja import Router, Schema
 from ninja.errors import HttpError
 from django.utils.timezone import make_naive
@@ -70,7 +71,7 @@ def extract_entity_relations(request, payload: TopicEntityRelationCreateRequest)
     try:
         with OpenAI() as client:
             response = client.responses.parse(
-                model="gpt-5",
+                model=settings.DEFAULT_AI_MODEL,
                 input=prompt,
                 text_format=_TopicEntityRelationResponse,
             )

--- a/semanticnews/topics/utils/timeline/api.py
+++ b/semanticnews/topics/utils/timeline/api.py
@@ -3,6 +3,7 @@
 from datetime import date
 from typing import List, Optional
 
+from django.conf import settings
 from ninja import Router, Schema
 from ninja.errors import HttpError
 from django.db.models import F, Value
@@ -156,7 +157,7 @@ def suggest_topic_events(request, payload: TimelineSuggestRequest):
 
     with OpenAI() as client:
         response = client.responses.parse(
-            model="gpt-5",
+            model=settings.DEFAULT_AI_MODEL,
             tools=[{"type": "web_search_preview"}],
             input=prompt,
             text_format=TimelineEventList,


### PR DESCRIPTION
## Summary
- define a DEFAULT_AI_MODEL setting with an environment override
- route text-generation API calls through the new setting instead of hard-coded models

## Testing
- pytest *(fails: Requested setting DATABASES, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_b_68d78fb5a680832881edc79b4ca70c35