### PR TITLE
Refactor locality configuration into settings

### DIFF
--- a/semanticnews/agenda/forms.py
+++ b/semanticnews/agenda/forms.py
@@ -1,19 +1,21 @@
-from datetime import date
 import calendar
+from datetime import date
 
 from django import forms
 from django.utils import timezone
 
-from .models import Locality, Category
+from semanticnews.agenda.localities import get_locality_form_choices
+
+from .models import Category
 
 
 class EventSuggestForm(forms.Form):
     start_date = forms.DateField()
     end_date = forms.DateField()
-    locality = forms.ModelChoiceField(
-        queryset=Locality.objects.all().order_by("-is_default", "name"),
+    locality = forms.ChoiceField(
+        choices=get_locality_form_choices(),
         required=False,
-        empty_label="Global",
+        label="Locality",
     )
     categories = forms.ModelMultipleChoiceField(queryset=Category.objects.all(), required=False)
 
@@ -26,6 +28,10 @@ class EventSuggestForm(forms.Form):
             self.initial.setdefault('start_date', first)
             self.initial.setdefault('end_date', last)
 
+    def clean_locality(self):
+        value = self.cleaned_data.get("locality")
+        return value or None
+
 
 class FindMajorEventsForm(forms.Form):
     now = timezone.now()
@@ -35,8 +41,10 @@ class FindMajorEventsForm(forms.Form):
     year = forms.ChoiceField(choices=YEAR_CHOICES, initial=now.year, label="Year")
     month = forms.ChoiceField(choices=MONTH_CHOICES, initial=now.month, label="Month")
 
-    locality = forms.ModelChoiceField(
-        queryset=Locality.objects.all(), required=False, empty_label="(Any)", label="Locality"
+    locality = forms.ChoiceField(
+        choices=get_locality_form_choices(blank_label="(Any)"),
+        required=False,
+        label="Locality",
     )
 
     categories = forms.ModelMultipleChoiceField(
@@ -52,3 +60,7 @@ class FindMajorEventsForm(forms.Form):
 
     def clean_year(self):
         return int(self.cleaned_data["year"])
+
+    def clean_locality(self):
+        value = self.cleaned_data.get("locality")
+        return value or None

--- a/semanticnews/agenda/localities.py
+++ b/semanticnews/agenda/localities.py
@@ -1,0 +1,96 @@
+"""Utility helpers for working with locality configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+from django.conf import settings
+
+
+@dataclass(frozen=True)
+class LocalityOption:
+    """Simple representation of a configured locality option."""
+
+    code: str
+    label: str
+    is_default: bool = False
+
+
+def _settings_localities() -> Sequence[tuple[str, str]]:
+    """Return the locality tuples defined in settings."""
+
+    localities: Iterable[tuple[str, str]] = getattr(settings, "LOCALITIES", ())
+    return tuple(localities)
+
+
+def get_default_locality_code() -> str | None:
+    """Return the configured default locality code, if any."""
+
+    return getattr(settings, "DEFAULT_LOCALITY", None)
+
+
+def get_locality_options() -> List[LocalityOption]:
+    """Return configured localities sorted with the default first."""
+
+    default_code = get_default_locality_code()
+    options = [
+        LocalityOption(code=code, label=label, is_default=(code == default_code))
+        for code, label in _settings_localities()
+    ]
+
+    # Sort with the default first, remaining options alphabetically by label.
+    options.sort(key=lambda opt: (not opt.is_default, opt.label.lower()))
+    return options
+
+
+def get_locality_choices() -> List[tuple[str, str]]:
+    """Return choices tuple suitable for Django form/model fields."""
+
+    return [(opt.code, opt.label) for opt in get_locality_options()]
+
+
+def get_default_locality_label() -> str:
+    """Return the label of the default locality or a sensible fallback."""
+
+    default_code = get_default_locality_code()
+    if default_code:
+        label = get_locality_label(default_code)
+        if label:
+            return label
+    return "Global"
+
+
+def get_locality_label(code: str | None) -> str | None:
+    """Resolve a locality code to its configured human-readable label."""
+
+    if code is None:
+        return None
+    for opt in get_locality_options():
+        if opt.code == code:
+            return opt.label
+    return code
+
+
+def resolve_locality_code(value: str | None) -> str | None:
+    """Return the configured code for a value, accepting code or label."""
+
+    if value is None:
+        return None
+
+    for opt in get_locality_options():
+        if value == opt.code or value == opt.label:
+            return opt.code
+    return value
+
+
+def get_locality_form_choices(
+    include_blank: bool = True, *, blank_label: str | None = None
+) -> List[tuple[str, str]]:
+    """Return locality choices for forms, optionally prefixed with a blank."""
+
+    choices = get_locality_choices()
+    if include_blank:
+        resolved_label = blank_label or get_default_locality_label()
+        return [("", resolved_label)] + choices
+    return choices

--- a/semanticnews/agenda/migrations/0004_event_locality_settings.py
+++ b/semanticnews/agenda/migrations/0004_event_locality_settings.py
@@ -1,0 +1,38 @@
+from django.db import migrations, models
+
+
+def copy_locality_forward(apps, schema_editor):
+    Event = apps.get_model("agenda", "Event")
+
+    for event in Event.objects.select_related("locality").all():
+        if event.locality_id:
+            event.locality_name = event.locality.name
+            event.save(update_fields=["locality_name"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("agenda", "0003_alter_source_domain"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="event",
+            name="locality_name",
+            field=models.CharField(blank=True, max_length=100, null=True),
+        ),
+        migrations.RunPython(copy_locality_forward, migrations.RunPython.noop),
+        migrations.RemoveField(
+            model_name="event",
+            name="locality",
+        ),
+        migrations.DeleteModel(
+            name="Locality",
+        ),
+        migrations.RenameField(
+            model_name="event",
+            old_name="locality_name",
+            new_name="locality",
+        ),
+    ]

--- a/semanticnews/agenda/views.py
+++ b/semanticnews/agenda/views.py
@@ -7,7 +7,12 @@ from django.urls import reverse
 from django.db.models import Prefetch
 from pgvector.django import L2Distance
 
-from .models import Event, Locality, Category, Source
+from semanticnews.agenda.localities import (
+    get_default_locality_label,
+    get_locality_options,
+)
+
+from .models import Event, Category, Source
 from semanticnews.topics.models import Topic
 
 
@@ -74,7 +79,7 @@ def event_detail(request, year, month, day, slug):
         .distinct()
     )
 
-    localities = Locality.objects.all().order_by("-is_default", "name")
+    localities = get_locality_options()
 
     context = {
         "event": obj,
@@ -82,6 +87,7 @@ def event_detail(request, year, month, day, slug):
         "similar_events": similar_events,
         "exclude_events": exclude_events,
         "localities": localities,
+        "default_locality_label": get_default_locality_label(),
         "categories": categories,
         "domains": domains,
     }
@@ -192,7 +198,7 @@ def event_list(request, year, month=None, day=None):
         .distinct()
     )
 
-    localities = Locality.objects.all().order_by("-is_default", "name")
+    localities = get_locality_options()
 
     context = {
         "events": events,
@@ -201,6 +207,7 @@ def event_list(request, year, month=None, day=None):
         "end": end,
         "exclude_events": exclude_events,
         "localities": localities,
+        "default_locality_label": get_default_locality_label(),
         "categories": categories,
         "domains": domains,
         "prev_url": prev_url,

--- a/semanticnews/settings/base.py
+++ b/semanticnews/settings/base.py
@@ -152,6 +152,13 @@ LANGUAGES = [
 LOCALE_PATHS = [PACKAGE_ROOT / 'locale']
 
 
+# Locality configuration
+DEFAULT_LOCALITY = "global"
+LOCALITIES = [
+    ("global", _("Global")),
+]
+
+
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 

--- a/semanticnews/topics/utils/timeline/templates/topics/timeline/modal.html
+++ b/semanticnews/topics/utils/timeline/templates/topics/timeline/modal.html
@@ -55,10 +55,10 @@
               <div class="mb-3">
                 <label for="suggestLocality" class="form-label">{% trans "Locality" %}</label>
                 <select class="form-select" id="suggestLocality">
-                  <option value="">{% trans "Global" %}</option>
+                  <option value="">{{ default_locality_label|default:_("Global") }}</option>
                   {% if localities %}
                     {% for locality in localities %}
-                      <option value="{{ locality.name }}">{{ locality.name }}</option>
+                      <option value="{{ locality.code }}" data-label="{{ locality.label }}">{{ locality.label }}</option>
                     {% endfor %}
                   {% endif %}
                 </select>

--- a/semanticnews/topics/views.py
+++ b/semanticnews/topics/views.py
@@ -5,6 +5,11 @@ from pgvector.django import L2Distance
 import json
 
 from semanticnews.agenda.models import Event
+from semanticnews.agenda.localities import (
+    get_default_locality_label,
+    get_locality_options,
+)
+
 from .models import Topic
 from .utils.timeline.models import TopicEvent
 from .utils.mcps.models import MCPServer
@@ -223,6 +228,8 @@ def topics_detail_edit(request, topic_uuid, username):
         context["user_topics"] = Topic.objects.filter(created_by=request.user).exclude(
             uuid=topic.uuid
         )
+    context["localities"] = get_locality_options()
+    context["default_locality_label"] = get_default_locality_label()
     return render(
         request,
         "topics/topics_detail_edit.html",


### PR DESCRIPTION
## Summary
- configure locality defaults directly in settings and add helpers for resolving codes and labels
- update agenda models, forms, admin, views, and tests to use the shared locality utilities
- adjust timeline API, templates, and views and add a migration to drop the old Locality model

## Testing
- python manage.py test semanticnews.agenda *(fails: PostgreSQL server not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d79312fce48328b54669d06473aeff