### PR TITLE
Ensure OpenAI clients are closed after use

### DIFF
--- a/semanticnews/contents/models.py
+++ b/semanticnews/contents/models.py
@@ -65,11 +65,11 @@ class Content(models.Model):
 
     def get_embedding(self):
         if self.embedding is None or len(self.embedding) == 0 and self.markdown:
-            client = OpenAI()
-            embedding = client.embeddings.create(
-                input=self.markdown,
-                model='text-embedding-3-small'
-            ).data[0].embedding
+            with OpenAI() as client:
+                embedding = client.embeddings.create(
+                    input=self.markdown,
+                    model='text-embedding-3-small'
+                ).data[0].embedding
             return embedding
 
 

--- a/semanticnews/contents/sources/rss/models.py
+++ b/semanticnews/contents/sources/rss/models.py
@@ -167,13 +167,13 @@ class RssItem(models.Model):
         Combines the title and description of the item and uses OpenAI's
         Embedding API to compute the embedding vector.
         """
-        client = OpenAI()
-        # Prepare the text to be embedded
-        embed_text = f"{self.title}\n{self.description or ''}"
-        response = client.embeddings.create(
-            input=embed_text,
-            model='text-embedding-3-small'
-        )
+        with OpenAI() as client:
+            # Prepare the text to be embedded
+            embed_text = f"{self.title}\n{self.description or ''}"
+            response = client.embeddings.create(
+                input=embed_text,
+                model='text-embedding-3-small'
+            )
         self.embedding = response.data[0].embedding
         self.save()
 

--- a/semanticnews/topics/models.py
+++ b/semanticnews/topics/models.py
@@ -197,11 +197,11 @@ class Topic(models.Model):
         if not force and self.embedding is not None and len(self.embedding) > 0:
             return self.embedding
 
-        client = OpenAI()
-        embedding = client.embeddings.create(
-            input=self.build_context(),
-            model='text-embedding-3-small'
-        ).data[0].embedding
+        with OpenAI() as client:
+            embedding = client.embeddings.create(
+                input=self.build_context(),
+                model='text-embedding-3-small'
+            ).data[0].embedding
         return embedding
 
     @cached_property

--- a/semanticnews/users/models.py
+++ b/semanticnews/users/models.py
@@ -20,11 +20,11 @@ class User(AbstractUser):
 
     def get_embedding(self):
         if self.embedding is None or len(self.embedding) == 0:
-            client = OpenAI()
-            embedding = client.embeddings.create(
-                input=self.term,
-                model='text-embedding-3-small'
-            ).data[0].embedding
+            with OpenAI() as client:
+                embedding = client.embeddings.create(
+                    input=self.term,
+                    model='text-embedding-3-small'
+                ).data[0].embedding
             return embedding
 
 

--- a/semanticnews/views.py
+++ b/semanticnews/views.py
@@ -25,15 +25,15 @@ def search_results(request):
     events = Event.objects.none()
 
     if query:
-        client = OpenAI()
-        embedding = (
-            client.embeddings.create(
-                model="text-embedding-3-small",
-                input=query,
+        with OpenAI() as client:
+            embedding = (
+                client.embeddings.create(
+                    model="text-embedding-3-small",
+                    input=query,
+                )
+                .data[0]
+                .embedding
             )
-            .data[0]
-            .embedding
-        )
 
         topics = (
             Topic.objects.filter(status="published")


### PR DESCRIPTION
## Summary
- wrap synchronous OpenAI usage in context managers so transports close promptly and reduce leaked connections
- reuse a single context-managed client when generating agenda suggestions to avoid lingering HTTP sessions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d93557d17083289d66f3e5ab346e46