### PR TITLE
Add Celery tasks for topic data fetch and search

### DIFF
--- a/semanticnews/topics/utils/data/tasks.py
+++ b/semanticnews/topics/utils/data/tasks.py
@@ -1,0 +1,88 @@
+"""Celery tasks for topic data fetch and search operations."""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from celery import shared_task
+from django.conf import settings
+from ninja import Schema
+
+from ....openai import OpenAI
+from semanticnews.prompting import append_default_language_instruction
+
+
+class _TopicDataResponseSchema(Schema):
+    headers: List[str]
+    rows: List[List[str]]
+    name: str | None = None
+
+
+class _TopicDataSearchResponseSchema(_TopicDataResponseSchema):
+    sources: List[str]
+    explanation: str | None = None
+
+
+def _call_openai(prompt: str, *, model: str, schema: type[Schema]) -> Schema:
+    """Execute the OpenAI call and return the parsed response."""
+    with OpenAI() as client:
+        response = client.responses.parse(
+            model=model,
+            input=prompt,
+            tools=[{"type": "web_search_preview"}],
+            text_format=schema,
+        )
+    return response.output_parsed
+
+
+def _resolve_model(model: str | None) -> str:
+    """Return the provided model or fall back to the default configured model."""
+    if model:
+        return model
+    return settings.DEFAULT_AI_MODEL
+
+
+@shared_task(bind=True, autoretry_for=(Exception,), retry_backoff=True, retry_kwargs={"max_retries": 2})
+def fetch_topic_data_task(self, *, url: str, model: str | None = None) -> Dict[str, Any]:
+    """Fetch structured tabular data from a URL using the LLM."""
+    resolved_model = _resolve_model(model)
+    prompt = (
+        f"Fetch the tabular data from {url} and return it as JSON with keys 'headers', 'rows', "
+        "and optionally 'name' representing a concise title for the dataset."
+    )
+    prompt = append_default_language_instruction(prompt)
+
+    parsed = _call_openai(prompt, model=resolved_model, schema=_TopicDataResponseSchema)
+    return {
+        "headers": parsed.headers,
+        "rows": parsed.rows,
+        "name": parsed.name,
+    }
+
+
+@shared_task(bind=True, autoretry_for=(Exception,), retry_backoff=True, retry_kwargs={"max_retries": 2})
+def search_topic_data_task(
+    self,
+    *,
+    description: str,
+    model: str | None = None,
+) -> Dict[str, Any]:
+    """Search for tabular data matching a description using the LLM."""
+    resolved_model = _resolve_model(model)
+    prompt = (
+        "Find tabular data that matches the following description and return it as JSON with "
+        "keys 'headers', 'rows', 'sources' (a list of URLs), 'name', and optionally 'explanation' "
+        "(a brief note if the data does not fully match the request). Description: "
+        f"{description}"
+    )
+    prompt = append_default_language_instruction(prompt)
+
+    parsed = _call_openai(prompt, model=resolved_model, schema=_TopicDataSearchResponseSchema)
+
+    result: Dict[str, Any] = {
+        "headers": parsed.headers,
+        "rows": parsed.rows,
+        "name": parsed.name,
+        "sources": parsed.sources,
+        "explanation": parsed.explanation,
+    }
+    return result

--- a/semanticnews/topics/utils/data/tests.py
+++ b/semanticnews/topics/utils/data/tests.py
@@ -9,7 +9,7 @@ from semanticnews.topics.models import Topic
 class TopicDataSearchAPITests(TestCase):
     """Tests for the data search API endpoint."""
 
-    @patch("semanticnews.topics.utils.data.api.OpenAI")
+    @patch("semanticnews.topics.utils.data.tasks.OpenAI")
     def test_search_data_returns_table_and_sources(self, mock_openai):
         User = get_user_model()
         user = User.objects.create_user("user", "user@example.com", "password")
@@ -53,7 +53,7 @@ class TopicDataSearchAPITests(TestCase):
         _, kwargs = mock_client.responses.parse.call_args
         self.assertIn(get_default_language_instruction(), kwargs["input"])
 
-    @patch("semanticnews.topics.utils.data.api.OpenAI")
+    @patch("semanticnews.topics.utils.data.tasks.OpenAI")
     def test_search_data_returns_explanation_when_needed(self, mock_openai):
         User = get_user_model()
         user = User.objects.create_user("user2", "user2@example.com", "password")


### PR DESCRIPTION
## Summary
- add Celery tasks to encapsulate topic data fetch and search calls to OpenAI with retries
- update the topic data API endpoints to execute the new Celery tasks and keep response shaping consistent
- adjust the topic data tests to mock the OpenAI client in the new task module

## Testing
- python manage.py test semanticnews.topics.utils.data *(fails: no PostgreSQL server available in the test environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d962c98f7c832884e26c37d9f43f7c