### PR TITLE
Update topic data search to return a single source

### DIFF
--- a/semanticnews/topics/utils/data/api.py
+++ b/semanticnews/topics/utils/data/api.py
@@ -29,7 +29,7 @@ class TopicDataResult(Schema):
     headers: List[str]
     rows: List[List[str]]
     name: str | None = None
-    sources: List[str] | None = None
+    source: str | None = None
     explanation: str | None = None
     url: str | None = None
 
@@ -118,7 +118,13 @@ def _build_task_response(request: TopicDataRequest) -> TopicDataTaskResponse:
         "error": request.error_message,
     }
     if result_payload is not None:
-        schema_kwargs["result"] = TopicDataResult(**result_payload)
+        normalized_payload = dict(result_payload)
+        if "source" not in normalized_payload and "sources" in normalized_payload:
+            sources_value = normalized_payload.get("sources")
+            if isinstance(sources_value, list) and sources_value:
+                normalized_payload["source"] = sources_value[0]
+            normalized_payload.pop("sources", None)
+        schema_kwargs["result"] = TopicDataResult(**normalized_payload)
     else:
         schema_kwargs["result"] = None
     return TopicDataTaskResponse(**schema_kwargs)

--- a/semanticnews/topics/utils/data/tasks.py
+++ b/semanticnews/topics/utils/data/tasks.py
@@ -23,7 +23,7 @@ class _TopicDataResponseSchema(Schema):
 
 
 class _TopicDataSearchResponseSchema(_TopicDataResponseSchema):
-    sources: List[str]
+    source: str
     explanation: str | None = None
 
 
@@ -138,8 +138,10 @@ def search_topic_data_task(
     resolved_model = _resolve_model(model)
     prompt = (
         "Find tabular data that matches the following description and return it as JSON with "
-        "keys 'headers', 'rows', 'sources' (a list of URLs), 'name', and optionally 'explanation' "
-        "(a brief note if the data does not fully match the request). Description: "
+        "keys 'headers', 'rows', 'source' (the single URL where the tabular data appears), "
+        "'name', and optionally 'explanation' (a brief note if the data does not fully match the "
+        "request). The 'source' must point directly to the page containing the table, not to a "
+        "summary or search results. Description: "
         f"{description}"
     )
     prompt = append_default_language_instruction(prompt)
@@ -157,15 +159,13 @@ def search_topic_data_task(
         )
         raise
 
-    first_source = parsed.sources[0] if parsed.sources else None
-
     result: Dict[str, Any] = {
         "headers": parsed.headers,
         "rows": parsed.rows,
         "name": parsed.name,
-        "sources": parsed.sources,
+        "source": parsed.source,
         "explanation": parsed.explanation,
-        "url": first_source,
+        "url": parsed.source,
     }
     _update_request(
         request_id,

--- a/semanticnews/topics/utils/data/tests.py
+++ b/semanticnews/topics/utils/data/tests.py
@@ -23,7 +23,7 @@ class TopicDataSearchAPITests(TestCase):
             headers=["Year", "USD/TL"],
             rows=[["2023", "1.1"]],
             name="USD/TL Rates",
-            sources=["https://example.com/data"],
+            source="https://example.com/data",
             explanation=None,
         )
         mock_client.responses.parse.return_value = mock_response
@@ -45,7 +45,7 @@ class TopicDataSearchAPITests(TestCase):
                 "headers": ["Year", "USD/TL"],
                 "rows": [["2023", "1.1"]],
                 "name": "USD/TL Rates",
-                "sources": ["https://example.com/data"],
+                "source": "https://example.com/data",
             },
         )
         self.assertNotIn("explanation", response.json())
@@ -67,7 +67,7 @@ class TopicDataSearchAPITests(TestCase):
             headers=["Year", "USD/TL"],
             rows=[["2019", "5.7"]],
             name=None,
-            sources=["https://example.com/partial"],
+            source="https://example.com/partial",
             explanation="Only five years of data were found",
         )
         mock_client.responses.parse.return_value = mock_response
@@ -88,7 +88,7 @@ class TopicDataSearchAPITests(TestCase):
             {
                 "headers": ["Year", "USD/TL"],
                 "rows": [["2019", "5.7"]],
-                "sources": ["https://example.com/partial"],
+                "source": "https://example.com/partial",
                 "explanation": "Only five years of data were found",
             },
         )


### PR DESCRIPTION
## Summary
- normalize topic data search results to expose a single `source` URL instead of a list of sources
- refresh the OpenAI prompt, task handling, API schema, and UI logic to align with the new source field while keeping backward compatibility for stored requests
- update automated tests to cover the new payload shape

## Testing
- python manage.py test semanticnews.topics.utils.data *(fails: OperationalError: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_68df5cb23ff483288c9f3a9cf531b5ec