### PR TITLE
Allow empty topic data search results when no matches are found

### DIFF
--- a/semanticnews/topics/utils/data/tasks.py
+++ b/semanticnews/topics/utils/data/tasks.py
@@ -7,6 +7,7 @@ from celery import shared_task
 from django.conf import settings
 from django.utils import timezone
 from ninja import Schema
+from pydantic import Field
 
 from ....openai import OpenAI
 from semanticnews.prompting import append_default_language_instruction
@@ -17,13 +18,13 @@ _UNSET = object()
 
 
 class _TopicDataResponseSchema(Schema):
-    headers: List[str]
-    rows: List[List[str]]
+    headers: List[str] = Field(default_factory=list)
+    rows: List[List[str]] = Field(default_factory=list)
     name: str | None = None
 
 
 class _TopicDataSearchResponseSchema(_TopicDataResponseSchema):
-    sources: List[str]
+    sources: List[str] = Field(default_factory=list)
     explanation: str | None = None
 
 


### PR DESCRIPTION
## Summary
- allow topic data search responses to return empty tabular data without raising schema validation errors
- normalize stored request payloads so empty headers, rows, and sources are preserved consistently
- add a regression test covering empty search results

## Testing
- python manage.py test semanticnews.topics.utils.data *(fails: database connection is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68df82cb4b548328a81b318355cce0b5