### PR TITLE
Add support for passing extra visualization instructions to LLM

### DIFF
--- a/semanticnews/topics/tests.py
+++ b/semanticnews/topics/tests.py
@@ -641,7 +641,11 @@ class VisualizeDataAPITests(TestCase):
         insight = TopicDataInsight.objects.create(topic=topic, insight="Insight")
         insight.sources.add(data)
 
-        payload = {"topic_uuid": str(topic.uuid), "insight_id": insight.id}
+        payload = {
+            "topic_uuid": str(topic.uuid),
+            "insight_id": insight.id,
+            "instructions": "Highlight revenue trends.",
+        }
         response = self.client.post(
             "/api/topics/data/visualize", payload, content_type="application/json"
         )
@@ -656,6 +660,8 @@ class VisualizeDataAPITests(TestCase):
             "chart_type": "bar",
             "chart_data": {"labels": ["A"], "datasets": [{"label": "Values", "data": [1]}]},
         })
+        called_kwargs = mock_client.responses.parse.call_args.kwargs
+        self.assertIn("Highlight revenue trends.", called_kwargs["input"])
 
     @patch("semanticnews.topics.utils.data.api.OpenAI")
     def test_creates_visualization_with_chart_type(self, mock_openai):

--- a/semanticnews/topics/utils/data/api.py
+++ b/semanticnews/topics/utils/data/api.py
@@ -70,6 +70,7 @@ class TopicDataVisualizeRequest(Schema):
     insight_id: int | None = None
     insight: str | None = None
     chart_type: str | None = None
+    instructions: str | None = None
 
 
 class _ChartDataset(Schema):
@@ -426,6 +427,8 @@ def visualize_data(request, payload: TopicDataVisualizeRequest):
             "'chart_type' and 'data'. The 'data' should include 'labels' and 'datasets' "
             "formatted for Chart.js."
         )
+    if payload.instructions:
+        prompt += f" Please consider the following user instructions: {payload.instructions}"
     prompt = append_default_language_instruction(prompt)
     prompt += f"\n\n{tables_section}"
 

--- a/semanticnews/topics/utils/data/static/topics/data/topic_data.js
+++ b/semanticnews/topics/utils/data/static/topics/data/topic_data.js
@@ -28,6 +28,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const visualizeForm = document.getElementById('dataVisualizeForm');
   const visualizeOtherInput = document.getElementById('visualizeInsightOtherText');
   const chartTypeSelect = document.getElementById('visualizeChartType');
+  const visualizeInstructionsInput = document.getElementById('visualizeInstructions');
   const urlMode = document.getElementById('dataModeUrl');
   const searchMode = document.getElementById('dataModeSearch');
   let fetchedData = null;
@@ -630,6 +631,12 @@ document.addEventListener('DOMContentLoaded', () => {
       const chartType = chartTypeSelect ? chartTypeSelect.value : '';
       if (chartType) {
         body.chart_type = chartType;
+      }
+      if (visualizeInstructionsInput) {
+        const instructions = visualizeInstructionsInput.value.trim();
+        if (instructions) {
+          body.instructions = instructions;
+        }
       }
       try {
         const res = await fetch('/api/topics/data/visualize', {

--- a/semanticnews/topics/utils/data/templates/topics/data/visualize_modal.html
+++ b/semanticnews/topics/utils/data/templates/topics/data/visualize_modal.html
@@ -33,6 +33,10 @@
                             <option value="pie">{% trans "Pie" %}</option>
                         </select>
                     </div>
+                    <div class="mb-3">
+                        <label for="visualizeInstructions" class="form-label">{% trans "Extra instructions" %}</label>
+                        <textarea class="form-control" id="visualizeInstructions" name="instructions" rows="3" placeholder="{% trans 'Optional additional guidance for the visualization' %}"></textarea>
+                    </div>
                     <div class="modal-footer px-0">
                         <button type="button" class="btn btn-outline-secondary float-start me-auto" id="visualizeDataBtn">{% trans "Visualize" %}</button>
                     </div>


### PR DESCRIPTION
## Summary
- add an optional extra instructions textarea to the Visualize data modal and include it in visualization requests
- forward the additional instructions through the visualization API to the LLM and cover the behavior with a unit test

## Testing
- pytest semanticnews/topics/tests.py::VisualizeDataAPITests -q *(fails: Django apps aren't loaded without pytest-django configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68e0adf86f848328be054819bc2f3899