### PR TITLE
Restyle topic module cards for detail and edit views

### DIFF
--- a/semanticnews/topics/layouts.py
+++ b/semanticnews/topics/layouts.py
@@ -131,11 +131,11 @@ MODULE_REGISTRY: Dict[str, Dict[str, object]] = {
         "templates": {
             "detail": {
                 "template": "topics/timeline/overview_card.html",
-                "context": {},
+                "context": {"edit_mode": False},
             },
             "edit": {
                 "template": "topics/timeline/overview_card.html",
-                "context": {},
+                "context": {"edit_mode": True},
             },
         },
         "context_keys": ["timeline", "topic"],
@@ -144,11 +144,11 @@ MODULE_REGISTRY: Dict[str, Dict[str, object]] = {
         "templates": {
             "detail": {
                 "template": "topics/documents/card.html",
-                "context": {},
+                "context": {"edit_mode": False},
             },
             "edit": {
                 "template": "topics/documents/card.html",
-                "context": {},
+                "context": {"edit_mode": True},
             },
         },
         "context_keys": ["documents", "webpages", "topic"],

--- a/semanticnews/topics/templates/topics/timeline/overview_card.html
+++ b/semanticnews/topics/templates/topics/timeline/overview_card.html
@@ -1,16 +1,18 @@
 {% load i18n %}
 {% if timeline %}
-<div class="card mt-3" data-topic-timeline-card>
+<div class="mt-3{% if edit_mode %} card{% endif %}" data-topic-timeline-card>
 
-  <div class="card-body">
+  {% if edit_mode %}
+  <div class="card-header d-flex align-items-center">
+      <h6 class="fs-5 mb-0">
+          {% trans "Timeline" %}
+      </h6>
+  </div>
+  {% endif %}
 
-    <div class="card-title d-flex justify-content-between">
-        <h6 class="fs-5">
-            {% trans "Timeline" %}
-        </h6>
-    </div>
+  <div{% if edit_mode %} class="card-body"{% endif %}>
 
-    <div class="position-relative mt-4">
+    <div class="position-relative{% if edit_mode %} mt-4{% endif %}">
 
     {% for timeline_topic in timeline %}
 

--- a/semanticnews/topics/templates/topics/timeline/related_events_card.html
+++ b/semanticnews/topics/templates/topics/timeline/related_events_card.html
@@ -1,12 +1,14 @@
 {% load i18n %}
 {% if related_events %}
-<div class="card mt-3" data-related-events-card>
-  <div class="card-body" id="relatedEventsContainer" data-empty-message="{% trans 'No related events' %}">
-    <div class="card-title d-flex justify-content-between">
-        <h6 class="fs-5">
-            {% trans "Timeline" %}
-        </h6>
-    </div>
+<div class="mt-3{% if edit_mode %} card{% endif %}" data-related-events-card>
+  {% if edit_mode %}
+  <div class="card-header d-flex align-items-center">
+      <h6 class="fs-5 mb-0">
+          {% trans "Timeline" %}
+      </h6>
+  </div>
+  {% endif %}
+  <div{% if edit_mode %} class="card-body"{% endif %} id="relatedEventsContainer" data-empty-message="{% trans 'No related events' %}">
     {% for event in related_events %}
         {% include "agenda/event_list_item.html" with event=event show_remove=edit_mode show_add=False %}
     {% endfor %}

--- a/semanticnews/topics/utils/data/templates/topics/data/card.html
+++ b/semanticnews/topics/utils/data/templates/topics/data/card.html
@@ -1,9 +1,11 @@
 {% load i18n %}
-<div class="card my-3" id="topicDataContainer"{% if not datas %} style="display: none;"{% endif %}>
-    <div class="card-body d-flex flex-column">
-        <div class="d-flex justify-content-between align-items-center mb-2 flex-shrink-0">
+<div class="my-3{% if edit_mode %} card{% endif %}" id="topicDataContainer"{% if not datas %} style="display: none;"{% endif %}>
+    {% if edit_mode %}
+        <div class="card-header d-flex align-items-center">
             <h6 class="fs-5 mb-0">{% trans "Data" %}</h6>
         </div>
+    {% endif %}
+    <div class="d-flex flex-column{% if edit_mode %} card-body{% endif %}">
         {% if datas %}
         <ul class="nav nav-tabs mb-3 flex-shrink-0" id="topicDataTabs" role="tablist">
             {% for data in datas %}

--- a/semanticnews/topics/utils/data/templates/topics/data/visualization_card.html
+++ b/semanticnews/topics/utils/data/templates/topics/data/visualization_card.html
@@ -1,9 +1,11 @@
 {% load i18n json_extras %}
-<div class="card my-3" id="topicDataVisualizationsContainer"{% if not data_visualizations %} style="display: none;"{% endif %}>
-    <div class="card-body">
-        <div class="d-flex justify-content-between align-items-center mb-2">
+<div class="my-3{% if edit_mode %} card{% endif %}" id="topicDataVisualizationsContainer"{% if not data_visualizations %} style="display: none;"{% endif %}>
+    {% if edit_mode %}
+        <div class="card-header d-flex align-items-center">
             <h6 class="fs-5 mb-0">{% trans "Visualizations" %}</h6>
         </div>
+    {% endif %}
+    <div{% if edit_mode %} class="card-body"{% endif %}>
         <div
             id="topicDataVisualizationCards"
             data-edit-mode="{% if edit_mode %}true{% else %}false{% endif %}"

--- a/semanticnews/topics/utils/documents/templates/topics/documents/card.html
+++ b/semanticnews/topics/utils/documents/templates/topics/documents/card.html
@@ -1,12 +1,13 @@
 {% load i18n %}
 
-<div class="card mt-3" id="topicResourcesCard"
+<div class="mt-3{% if edit_mode %} card{% endif %}" id="topicResourcesCard"
      {% if not documents and not webpages and not edit_mode %}style="display:none;"{% endif %}>
-    <div class="card-body">
-        <div class="d-flex justify-content-between align-items-center mb-3">
-            <h6 class="fs-5 mb-0">{% trans "References" %}</h6>
-        </div>
-
+    {% if edit_mode %}
+    <div class="card-header d-flex align-items-center">
+        <h6 class="fs-5 mb-0">{% trans "References" %}</h6>
+    </div>
+    {% endif %}
+    <div{% if edit_mode %} class="card-body"{% endif %}>
         {% if documents or webpages %}
             {% if documents %}
                 <h6 class="text-uppercase text-secondary small fw-semibold mb-2">{% trans "Documents" %}</h6>

--- a/semanticnews/topics/utils/embeds/templates/topics/embeds/card.html
+++ b/semanticnews/topics/utils/embeds/templates/topics/embeds/card.html
@@ -1,9 +1,11 @@
 {% load i18n %}
-<div class="card my-3" id="topicMediaContainer"{% if not youtube_video and not tweets %} style="display: none;"{% endif %}>
-    <div class="card-body">
-        <div class="d-flex justify-content-between align-items-center mb-2">
+<div class="my-3{% if edit_mode %} card{% endif %}" id="topicMediaContainer"{% if not youtube_video and not tweets %} style="display: none;"{% endif %}>
+    {% if edit_mode %}
+        <div class="card-header d-flex align-items-center">
             <h6 class="fs-5 mb-0">{% trans "Media" %}</h6>
         </div>
+    {% endif %}
+    <div{% if edit_mode %} class="card-body"{% endif %}>
         {% if youtube_video %}
         <div class="ratio ratio-16x9">
             <iframe src="https://www.youtube.com/embed/{{ youtube_video.video_id }}" title="{{ youtube_video.title }}" allowfullscreen></iframe>

--- a/semanticnews/topics/utils/images/templates/topics/images/card.html
+++ b/semanticnews/topics/utils/images/templates/topics/images/card.html
@@ -35,9 +35,14 @@
     }
 </style>
 
-<div class="card my-3" id="topicImageContainer"{% if not topic.image %} style="display:none"{% endif %}
+<div class="my-3{% if edit_mode %} card{% endif %}" id="topicImageContainer"{% if not topic.image %} style="display:none"{% endif %}
      data-topic-image-card>
-    <div class="card-body">
+    {% if edit_mode %}
+    <div class="card-header d-flex align-items-center">
+        <h6 class="fs-5 mb-0">{% trans "Images" %}</h6>
+    </div>
+    {% endif %}
+    <div{% if edit_mode %} class="card-body"{% endif %}>
         <div class="img-card-wrap">
             <img
                     id="topicImageLatest"

--- a/semanticnews/topics/utils/narratives/templates/topics/narratives/card.html
+++ b/semanticnews/topics/utils/narratives/templates/topics/narratives/card.html
@@ -1,19 +1,19 @@
 {% load i18n markdown_extras %}
-<div class="card my-3" id="topicNarrativeContainer"{% if not latest_narrative %} style="display: none;"{% endif %}>
-    <div class="card-body">
-        <div class="d-flex justify-content-between align-items-center mb-2">
+<div class="my-3{% if edit_mode %} card{% endif %}" id="topicNarrativeContainer"{% if not latest_narrative %} style="display: none;"{% endif %}>
+    {% if edit_mode %}
+        <div class="card-header d-flex align-items-center">
             <h6 class="fs-5 mb-0">{% trans "Narrative" %}</h6>
 
-            {% if edit_mode %}
-                <div class="d-flex align-items-center gap-2" id="narrativePager" style="display:none;">
-                    <span class="small text-secondary me-2" id="narrativeCreatedAt"></span>
-                    <button class="btn btn-sm btn-outline-secondary" id="narrativePrev" aria-label="{% trans 'Previous narrative' %}">&lt;</button>
-                    <span class="small text-secondary" id="narrativePagerLabel">0/0</span>
-                    <button class="btn btn-sm btn-outline-secondary" id="narrativeNext" aria-label="{% trans 'Next narrative' %}">&gt;</button>
-                    <button class="btn btn-sm btn-outline-danger" id="narrativeDeleteBtn" aria-label="{% trans 'Delete narrative' %}"><i class="bi bi-trash"></i></button>
-                </div>
-            {% endif %}
+            <div class="d-flex align-items-center gap-2 ms-auto" id="narrativePager" style="display:none;">
+                <span class="small text-secondary me-2" id="narrativeCreatedAt"></span>
+                <button class="btn btn-sm btn-outline-secondary" id="narrativePrev" aria-label="{% trans 'Previous narrative' %}">&lt;</button>
+                <span class="small text-secondary" id="narrativePagerLabel">0/0</span>
+                <button class="btn btn-sm btn-outline-secondary" id="narrativeNext" aria-label="{% trans 'Next narrative' %}">&gt;</button>
+                <button class="btn btn-sm btn-outline-danger" id="narrativeDeleteBtn" aria-label="{% trans 'Delete narrative' %}"><i class="bi bi-trash"></i></button>
+            </div>
         </div>
+    {% endif %}
+    <div{% if edit_mode %} class="card-body"{% endif %}>
         <div id="topicNarrativeText">{% if latest_narrative %}{{ latest_narrative.narrative|markdownify }}{% endif %}</div>
     </div>
 </div>

--- a/semanticnews/topics/utils/recaps/templates/topics/recaps/card.html
+++ b/semanticnews/topics/utils/recaps/templates/topics/recaps/card.html
@@ -1,29 +1,28 @@
 {% load i18n markdown_extras %}
-<div class="card my-3" id="topicRecapContainer"
+<div class="my-3{% if edit_mode %} card{% endif %}" id="topicRecapContainer"
      {% if not latest_recap or not latest_recap.recap %}style="display:none;"{% endif %}>
-    <div class="card-body">
-        <div class="d-flex justify-content-between align-items-center mb-2">
+    {% if edit_mode %}
+        <div class="card-header d-flex align-items-center">
             <h6 class="fs-5 mb-0">{% trans "Recap" %}</h6>
 
-            {# EDIT MODE controls only #}
-            {% if edit_mode %}
-                <div class="d-flex align-items-center gap-2" id="recapPager" style="display:none;">
-                    <span class="small text-secondary me-2" id="recapCreatedAt"></span>
-                    <button class="btn btn-sm btn-outline-secondary d-none" id="recapPrev" data-show-when-multiple
-                            aria-label="{% trans 'Previous recap' %}">&lt;
-                    </button>
-                    <span class="small text-secondary d-none" id="recapPagerLabel" data-show-when-multiple>0/0</span>
-                    <button class="btn btn-sm btn-outline-secondary d-none" id="recapNext" data-show-when-multiple
-                            aria-label="{% trans 'Next recap' %}">&gt;
-                    </button>
-                    <button class="btn btn-sm btn-outline-danger" id="recapDeleteBtn"
-                            aria-label="{% trans 'Delete recap' %}">
-                        <i class="bi bi-trash"></i>
-                    </button>
-                </div>
-            {% endif %}
+            <div class="d-flex align-items-center gap-2 ms-auto" id="recapPager" style="display:none;">
+                <span class="small text-secondary me-2" id="recapCreatedAt"></span>
+                <button class="btn btn-sm btn-outline-secondary d-none" id="recapPrev" data-show-when-multiple
+                        aria-label="{% trans 'Previous recap' %}">&lt;
+                </button>
+                <span class="small text-secondary d-none" id="recapPagerLabel" data-show-when-multiple>0/0</span>
+                <button class="btn btn-sm btn-outline-secondary d-none" id="recapNext" data-show-when-multiple
+                        aria-label="{% trans 'Next recap' %}">&gt;
+                </button>
+                <button class="btn btn-sm btn-outline-danger" id="recapDeleteBtn"
+                        aria-label="{% trans 'Delete recap' %}">
+                    <i class="bi bi-trash"></i>
+                </button>
+            </div>
         </div>
+    {% endif %}
 
+    <div{% if edit_mode %} class="card-body"{% endif %}>
         <div id="topicRecapText">
             {% if latest_recap and latest_recap.recap %}
                 {{ latest_recap.recap|markdownify }}

--- a/semanticnews/topics/utils/relations/templates/topics/relations/card.html
+++ b/semanticnews/topics/utils/relations/templates/topics/relations/card.html
@@ -1,19 +1,19 @@
 {% load i18n %}
-<div class="card my-3" id="topicRelationContainer"{% if not latest_relation %} style="display: none;"{% endif %}>
-    <div class="card-body">
-        <div class="d-flex justify-content-between align-items-center mb-2">
+<div class="my-3{% if edit_mode %} card{% endif %}" id="topicRelationContainer"{% if not latest_relation %} style="display: none;"{% endif %}>
+    {% if edit_mode %}
+        <div class="card-header d-flex align-items-center">
             <h6 class="fs-5 mb-0">{% trans "Relations" %}</h6>
 
-            {% if edit_mode %}
-                <div class="d-flex align-items-center gap-2" id="relationPager" style="display:none;">
-                    <span class="small text-secondary me-2" id="relationCreatedAt"></span>
-                    <button class="btn btn-sm btn-outline-secondary" id="relationPrev" aria-label="{% trans 'Previous relations' %}">&lt;</button>
-                    <span class="small text-secondary" id="relationPagerLabel">0/0</span>
-                    <button class="btn btn-sm btn-outline-secondary" id="relationNext" aria-label="{% trans 'Next relations' %}">&gt;</button>
-                    <button class="btn btn-sm btn-outline-danger" id="relationDeleteBtn" aria-label="{% trans 'Delete relations' %}"><i class="bi bi-trash"></i></button>
-                </div>
-            {% endif %}
+            <div class="d-flex align-items-center gap-2 ms-auto" id="relationPager" style="display:none;">
+                <span class="small text-secondary me-2" id="relationCreatedAt"></span>
+                <button class="btn btn-sm btn-outline-secondary" id="relationPrev" aria-label="{% trans 'Previous relations' %}">&lt;</button>
+                <span class="small text-secondary" id="relationPagerLabel">0/0</span>
+                <button class="btn btn-sm btn-outline-secondary" id="relationNext" aria-label="{% trans 'Next relations' %}">&gt;</button>
+                <button class="btn btn-sm btn-outline-danger" id="relationDeleteBtn" aria-label="{% trans 'Delete relations' %}"><i class="bi bi-trash"></i></button>
+            </div>
         </div>
+    {% endif %}
+    <div{% if edit_mode %} class="card-body"{% endif %}>
         <div id="topicRelationGraph" data-relations='{{ relations_json|escape }}' style="height: 400px;"></div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- remove card chrome and headings from topic detail module cards for a flatter presentation
- add card headers in edit mode and relocate module controls into the header
- provide edit-mode context for timeline and document modules to support the updated structure

## Testing
- python -m compileall semanticnews

------
https://chatgpt.com/codex/tasks/task_b_68e2a9e75d5c8328a245da312d068586