### PR TITLE
Add AI-assisted text transformations to topic text modal

### DIFF
--- a/semanticnews/topics/utils/text/templates/topics/text/modal.html
+++ b/semanticnews/topics/utils/text/templates/topics/text/modal.html
@@ -20,9 +20,37 @@
                         <textarea class="form-control" id="textContent" name="content" rows="8"></textarea>
                     </div>
                 </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">{% trans "Cancel" %}</button>
-                    <button type="submit" class="btn btn-primary" id="textSaveBtn">{% trans "Save text" %}</button>
+                <div class="modal-footer flex-wrap gap-2 justify-content-between">
+                    <div class="d-flex flex-wrap gap-2 me-auto">
+                        <button
+                            type="button"
+                            class="btn btn-outline-primary"
+                            id="textReviseBtn"
+                            data-loading-label="{% trans 'Revising…' %}"
+                        >
+                            {% trans "Revise" %}
+                        </button>
+                        <button
+                            type="button"
+                            class="btn btn-outline-primary"
+                            id="textShortenBtn"
+                            data-loading-label="{% trans 'Shortening…' %}"
+                        >
+                            {% trans "Shorten" %}
+                        </button>
+                        <button
+                            type="button"
+                            class="btn btn-outline-primary"
+                            id="textExpandBtn"
+                            data-loading-label="{% trans 'Expanding…' %}"
+                        >
+                            {% trans "Expand" %}
+                        </button>
+                    </div>
+                    <div class="d-flex flex-wrap gap-2">
+                        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">{% trans "Cancel" %}</button>
+                        <button type="submit" class="btn btn-primary" id="textSaveBtn">{% trans "Save text" %}</button>
+                    </div>
                 </div>
             </form>
         </div>

--- a/semanticnews/topics/utils/text/tests.py
+++ b/semanticnews/topics/utils/text/tests.py
@@ -1,9 +1,11 @@
 import json
+from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
 from semanticnews.topics.models import Topic, TopicModuleLayout
+from semanticnews.prompting import get_default_language_instruction
 from .models import TopicText
 
 
@@ -49,3 +51,73 @@ class TopicTextAPITests(TestCase):
         self.assertFalse(
             TopicModuleLayout.objects.filter(topic=self.topic, module_key=f'text:{text.id}').exists()
         )
+
+    @patch('semanticnews.topics.utils.text.api.OpenAI')
+    def test_revise_text_returns_transformed_content(self, mock_openai):
+        mock_client = MagicMock()
+        mock_openai.return_value.__enter__.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.output_parsed = MagicMock(content='Improved text')
+        mock_client.responses.parse.return_value = mock_response
+
+        response = self._post_json(
+            '/api/topics/text/revise',
+            {'topic_uuid': str(self.topic.uuid), 'content': 'Original text'},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'content': 'Improved text'})
+        mock_client.responses.parse.assert_called_once()
+        _, kwargs = mock_client.responses.parse.call_args
+        self.assertIn('Original text', kwargs['input'])
+        self.assertIn('Revise the text', kwargs['input'])
+        self.assertIn('Sample Topic', kwargs['input'])
+        self.assertIn(get_default_language_instruction(), kwargs['input'])
+
+    @patch('semanticnews.topics.utils.text.api.OpenAI')
+    def test_shorten_text_returns_transformed_content(self, mock_openai):
+        mock_client = MagicMock()
+        mock_openai.return_value.__enter__.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.output_parsed = MagicMock(content='Short version')
+        mock_client.responses.parse.return_value = mock_response
+
+        response = self._post_json(
+            '/api/topics/text/shorten',
+            {'topic_uuid': str(self.topic.uuid), 'content': 'Long detailed explanation'},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'content': 'Short version'})
+        mock_client.responses.parse.assert_called_once()
+        _, kwargs = mock_client.responses.parse.call_args
+        self.assertIn('Shorten the text', kwargs['input'])
+        self.assertIn(get_default_language_instruction(), kwargs['input'])
+
+    @patch('semanticnews.topics.utils.text.api.OpenAI')
+    def test_expand_text_returns_transformed_content(self, mock_openai):
+        mock_client = MagicMock()
+        mock_openai.return_value.__enter__.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.output_parsed = MagicMock(content='Expanded version with detail')
+        mock_client.responses.parse.return_value = mock_response
+
+        response = self._post_json(
+            '/api/topics/text/expand',
+            {'topic_uuid': str(self.topic.uuid), 'content': 'Brief summary'},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'content': 'Expanded version with detail'})
+        mock_client.responses.parse.assert_called_once()
+        _, kwargs = mock_client.responses.parse.call_args
+        self.assertIn('Expand the text', kwargs['input'])
+        self.assertIn(get_default_language_instruction(), kwargs['input'])
+
+    def test_transform_requires_content(self):
+        response = self._post_json(
+            '/api/topics/text/revise',
+            {'topic_uuid': str(self.topic.uuid), 'content': '   '},
+        )
+
+        self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
## Summary
- add revise, shorten, and expand buttons to the topic text modal and wire them to new API endpoints
- implement backend handlers that call OpenAI with the topic context to transform text content
- extend tests to cover the new transformation endpoints and prompt construction

## Testing
- python manage.py test semanticnews/topics/utils/text *(fails: requires PostgreSQL instance)*

------
https://chatgpt.com/codex/tasks/task_b_68e2ca7925cc8328b6e3e490dfac345d