### PR TITLE
Hide references card without content in topic edit view

### DIFF
--- a/semanticnews/topics/utils/documents/templates/topics/documents/card.html
+++ b/semanticnews/topics/utils/documents/templates/topics/documents/card.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 <div class="mt-3{% if edit_mode %} card{% endif %}" id="topicResourcesCard"
-     {% if not documents and not webpages and not edit_mode %}style="display:none;"{% endif %}>
+     {% if not documents and not webpages %}style="display:none;"{% endif %}>
     {% if edit_mode %}
     <div class="card-header d-flex align-items-center">
         <h6 class="fs-5 mb-0">{% trans "References" %}</h6>


### PR DESCRIPTION
## Summary
- hide the references card in topic edit view when there are no documents or webpages attached

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e2d05e68fc8328a0604736ca590305