### PR TITLE
Require recaps before publishing topics

### DIFF
--- a/semanticnews/topics/api.py
+++ b/semanticnews/topics/api.py
@@ -208,8 +208,13 @@ def set_topic_status(request, payload: TopicStatusUpdateRequest):
     if payload.status not in valid_statuses:
         raise HttpError(400, "Invalid status")
 
-    if payload.status == "published" and not topic.title:
-        raise HttpError(400, "A title is required to publish a topic.")
+    if payload.status == "published":
+        if not topic.title:
+            raise HttpError(400, "A title is required to publish a topic.")
+
+        has_finished_recap = topic.recaps.filter(status="finished").exists()
+        if not has_finished_recap:
+            raise HttpError(400, "A recap is required to publish a topic.")
 
     topic.status = payload.status
     topic.save(update_fields=["status"])

--- a/semanticnews/topics/models.py
+++ b/semanticnews/topics/models.py
@@ -109,8 +109,16 @@ class Topic(models.Model):
 
     def clean(self):
         super().clean()
-        if self.status == "published" and not self.title:
-            raise ValidationError({"title": "A title is required to publish a topic."})
+        if self.status == "published":
+            if not self.title:
+                raise ValidationError({"title": "A title is required to publish a topic."})
+
+            has_finished_recap = False
+            if self.pk:
+                has_finished_recap = self.recaps.filter(status="finished").exists()
+
+            if not has_finished_recap:
+                raise ValidationError({"status": "A recap is required to publish a topic."})
 
     def full_clean(self, exclude=None, validate_unique=True, validate_constraints=True):
         """Run validation while skipping the embedding field.


### PR DESCRIPTION
## Summary
- block publishing topics that lack a completed recap by updating model and API validation
- keep the title requirement while adding finished recap checks for published status
- expand topic status tests to cover the recap requirement and adjust existing publish test

## Testing
- python manage.py test semanticnews.topics.tests.SetTopicStatusAPITests *(fails: ImportError: cannot import name 'TopicKeyword')*

------
https://chatgpt.com/codex/tasks/task_b_68e346309c0c8328b72b43546c16e0a0