### PR TITLE
Show chart fallback for topics without cover images

### DIFF
--- a/semanticnews/profiles/templates/profiles/user_profile.html
+++ b/semanticnews/profiles/templates/profiles/user_profile.html
@@ -39,4 +39,9 @@
 
 {% endblock %}
 
+{% block extra_js %}
+    {{ block.super }}
+    {% include "topics/data/scripts.html" %}
+{% endblock %}
+
 

--- a/semanticnews/templates/home.html
+++ b/semanticnews/templates/home.html
@@ -53,4 +53,5 @@
 
 {% block extra_js %}
     {{ block.super }}
+    {% include "topics/data/scripts.html" %}
 {% endblock %}

--- a/semanticnews/templates/search_results.html
+++ b/semanticnews/templates/search_results.html
@@ -26,3 +26,8 @@
     </div>
 </div>
 {% endblock %}
+
+{% block extra_js %}
+    {{ block.super }}
+    {% include "topics/data/scripts.html" %}
+{% endblock %}

--- a/semanticnews/templates/users/user_profile.html
+++ b/semanticnews/templates/users/user_profile.html
@@ -71,50 +71,50 @@
 
 {% endblock %}
 
-
 {% block extra_js %}
+    {{ block.super }}
+    {% include "topics/data/scripts.html" %}
+    {% include "bookmarks_js.html" %}
 
-{% include "bookmarks_js.html" %}
+    <script>
+        document.addEventListener('click', async e => {
+            const btn = e.target.closest('.delete-topic-btn');
+            if (!btn) return;
 
-<script>
-    document.addEventListener('click', async e => {
-        const btn = e.target.closest('.delete-topic-btn');
-        if (!btn) return;
+            e.preventDefault();
+            disposeTooltip(btn);
 
-        e.preventDefault();
-        disposeTooltip(btn);
+            if (!confirm("{% trans "Are you sure you want to delete this draft?" %}")) return;
 
-        if (!confirm("{% trans "Are you sure you want to delete this draft?" %}")) return;
+            const url = btn.dataset.url;
+            const resp = await fetch(url, {
+                method: 'POST',
+                headers: {
+                    'X-CSRFToken': getCookie('csrftoken'),
+                    'X-Requested-With': 'XMLHttpRequest',
+                },
+            });
 
-        const url = btn.dataset.url;
-        const resp = await fetch(url, {
-            method: 'POST',
-            headers: {
-                'X-CSRFToken': getCookie('csrftoken'),
-                'X-Requested-With': 'XMLHttpRequest',
-            },
-        });
+            const data = await resp.json();
+            if (resp.ok) {
+                appendToast('{% trans "Success!" %}', data.message, 'success');
 
-        const data = await resp.json();
-        if (resp.ok) {
-            appendToast('{% trans "Success!" %}', data.message, 'success');
+                // Remove the topic card from the DOM:
+                const card = document.querySelector(
+                    `[data-topic-uuid="${data.uuid}"]`
+                );
+                if (card) card.remove();
 
-            // Remove the topic card from the DOM:
-            const card = document.querySelector(
-                `[data-topic-uuid="${data.uuid}"]`
-            );
-            if (card) card.remove();
-
-            // Optionally, if the list is now empty, show a "No topics" message:
-            const container = document.querySelector('#user-topics-container');
-            if (container && container.children.length === 0) {
-                container.innerHTML = '<span class="text-secondary">{% trans "No topic created yet." %}</span>';
+                // Optionally, if the list is now empty, show a "No topics" message:
+                const container = document.querySelector('#user-topics-container');
+                if (container && container.children.length === 0) {
+                    container.innerHTML = '<span class="text-secondary">{% trans "No topic created yet." %}</span>';
+                }
+            } else {
+                appendToast('{% trans "Error!" %}', data.error, 'danger');
             }
-        } else {
-            appendToast('{% trans "Error!" %}', data.error, 'danger');
-        }
-        showToasts();
-    });
-</script>
+            showToasts();
+        });
+    </script>
 
 {% endblock %}

--- a/semanticnews/topics/templates/topics/topics_list.html
+++ b/semanticnews/topics/templates/topics/topics_list.html
@@ -34,4 +34,5 @@
 
 {% block extra_js %}
     {{ block.super }}
+    {% include "topics/data/scripts.html" %}
 {% endblock %}

--- a/semanticnews/topics/templates/topics/topics_list_item.html
+++ b/semanticnews/topics/templates/topics/topics_list_item.html
@@ -1,4 +1,4 @@
-{% load i18n markdown_extras %}
+{% load i18n markdown_extras json_extras %}
 
 <div class="position-relative mb-3 pb-3 border-bottom" data-topic-uuid="{{ topic.uuid }}">
 
@@ -49,6 +49,22 @@
 
         {% if topic.thumbnail %}
             <img src="{{ topic.thumbnail.url }}" alt="{{ topic.title }}" class="img-fluid rounded mb-2 float-start me-3 w-50">
+        {% else %}
+            {% with topic.data_visualizations.all|first as first_visualization %}
+                {% if first_visualization %}
+                    <div
+                        class="chart-container rounded border mb-2 float-start me-3 w-50 bg-body"
+                        data-visualization-preview="{{ first_visualization.id }}"
+                    >
+                        <canvas
+                            id="dataVisualizationChart{{ first_visualization.id }}"
+                            class="data-visualization-chart w-100"
+                            data-chart-type="{{ first_visualization.chart_type }}"
+                            data-chart="{{ first_visualization.chart_data|jsonify }}"
+                        ></canvas>
+                    </div>
+                {% endif %}
+            {% endwith %}
         {% endif %}
 
         {% with topic.recaps.last as latest_recap %}


### PR DESCRIPTION
## Summary
- render the first data visualization chart when a topic list item has no cover image
- prefetch topic data visualizations in list and profile views and load chart scripts where list items appear
- cover the new behavior with a home page regression test

## Testing
- `python manage.py test` *(fails: PostgreSQL server is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e3503ebe1c8328bb16107f74ce6028