### PR TITLE
Separate data tables into individual modules

### DIFF
--- a/semanticnews/topics/utils/data/templates/topics/data/card.html
+++ b/semanticnews/topics/utils/data/templates/topics/data/card.html
@@ -1,80 +1,90 @@
 {% load i18n %}
-<div class="my-3{% if edit_mode %} card{% endif %}" id="topicDataContainer"{% if not datas %} style="display: none;"{% endif %}>
+{% with dataset=data %}
+<div class="my-3{% if edit_mode %} card{% endif %}">
     {% if edit_mode %}
         <div class="card-header d-flex align-items-center">
             <h6 class="fs-5 mb-0">{% trans "Data" %}</h6>
             <div class="d-flex align-items-center gap-2 ms-auto" data-topic-module-header-actions></div>
         </div>
     {% endif %}
-    <div class="d-flex flex-column{% if edit_mode %} card-body{% endif %}">
-        {% if datas %}
-        <ul class="nav nav-tabs mb-3 flex-shrink-0" id="topicDataTabs" role="tablist">
-            {% for data in datas %}
-            <li class="nav-item" role="presentation">
-                <button class="nav-link {% if forloop.first %}active{% endif %}" id="data-tab-{{ forloop.counter }}"
-                        data-bs-toggle="tab" data-bs-target="#data-pane-{{ forloop.counter }}" type="button"
-                        role="tab" {% if forloop.first %}aria-selected="true"{% else %}aria-selected="false"{% endif %}>
-                    {% if data.name %}{{ data.name }}{% else %}{{ data.created_at|date:"Y-m-d" }}{% endif %}
-                </button>
-            </li>
-            {% endfor %}
-        </ul>
-        <div class="tab-content flex-grow-1" id="topicDataTabsContent">
-            {% for data in datas %}
-            <div class="tab-pane fade {% if forloop.first %}show active{% endif %}" id="data-pane-{{ forloop.counter }}"
-                 role="tabpanel" aria-labelledby="data-tab-{{ forloop.counter }}">
-                <div class="table-responsive">
-                    <table class="table table-sm mb-0">
-                        <thead class="table-light">
-                            <tr>
-                                {% for header in data.data.headers %}
-                                    <th>{{ header }}</th>
-                                {% endfor %}
-                            </tr>
-                        </thead>
-                    </table>
-                    <!-- Scrollable rows -->
-                    <div style="max-height: 300px; overflow-y: auto;">
-                        <table class="table table-sm mb-0">
-                            <tbody>
-                                {% for row in data.data.rows %}
+    <div{% if edit_mode %} class="card-body"{% endif %}>
+        {% if dataset %}
+            {% with table=dataset.data %}
+                {% with headers=table.headers rows=table.rows %}
+                    {% if headers or rows %}
+                        <div class="table-responsive mb-3" style="max-height: 300px; overflow-y: auto;">
+                            <table class="table table-sm mb-0">
+                                {% if headers %}
+                                <thead class="table-light">
                                     <tr>
-                                        {% for cell in row %}
-                                            <td>{{ cell }}</td>
+                                        {% for header in headers %}
+                                            <th>{{ header }}</th>
                                         {% endfor %}
                                     </tr>
-                                {% endfor %}
-                            </tbody>
-                        </table>
-                    </div>
-                    {% if data.sources %}
-                    <div class="small text-muted mt-2">
-                        <strong>{% trans "Sources" %}:</strong>
-                        <ul class="mb-0 ps-3">
-                            {% for source in data.sources %}
-                                <li><a href="{{ source }}" target="_blank" rel="noopener noreferrer">{{ source }}</a></li>
-                            {% endfor %}
-                        </ul>
-                    </div>
+                                </thead>
+                                {% endif %}
+                                <tbody>
+                                    {% if rows %}
+                                        {% for row in rows %}
+                                            <tr>
+                                                {% for cell in row %}
+                                                    <td>{{ cell }}</td>
+                                                {% endfor %}
+                                            </tr>
+                                        {% endfor %}
+                                    {% else %}
+                                        <tr>
+                                            <td class="text-muted fst-italic"{% if headers %} colspan="{{ headers|length }}"{% endif %}>
+                                                {% trans "No rows available." %}
+                                            </td>
+                                        </tr>
+                                    {% endif %}
+                                </tbody>
+                            </table>
+                        </div>
+                    {% else %}
+                        <p class="text-muted fst-italic mb-3">{% trans "This data table is empty." %}</p>
                     {% endif %}
-                    {% if data.explanation %}
-                    <p class="small text-muted mt-2">{{ data.explanation }}</p>
-                    {% endif %}
-                </div>
+                {% endwith %}
+            {% endwith %}
+
+            <p class="fw-semibold mb-2">
+                {% if dataset.name %}
+                    {{ dataset.name }}
+                {% else %}
+                    {{ dataset.created_at|date:"Y-m-d" }}
+                {% endif %}
+            </p>
+
+            {% if dataset.sources %}
+            <div class="small text-muted mb-2">
+                <strong>{% trans "Sources" %}:</strong>
+                <ul class="mb-0 ps-3">
+                    {% for source in dataset.sources %}
+                        <li><a href="{{ source }}" target="_blank" rel="noopener noreferrer">{{ source }}</a></li>
+                    {% endfor %}
+                </ul>
             </div>
-            {% endfor %}
-        </div>
+            {% endif %}
+
+            {% if dataset.explanation %}
+            <p class="small text-muted mb-0">{{ dataset.explanation }}</p>
+            {% endif %}
+        {% else %}
+            <p class="text-muted fst-italic mb-0">{% trans "This data table could not be found." %}</p>
         {% endif %}
-        {% if data_insights %}
-        <hr>
-        <h6 class="fs-6 mt-3">{% trans "Insights" %}</h6>
-        <ul class="mb-0">
-            {% for insight in data_insights %}
-            <li>
-                {{ insight.insight }}
-            </li>
-            {% endfor %}
-        </ul>
+
+        {% if show_data_insights and data_insights %}
+            <hr>
+            <h6 class="fs-6 mt-3">{% trans "Insights" %}</h6>
+            <ul class="mb-0">
+                {% for insight in data_insights %}
+                <li>
+                    {{ insight.insight }}
+                </li>
+                {% endfor %}
+            </ul>
         {% endif %}
     </div>
 </div>
+{% endwith %}


### PR DESCRIPTION
## Summary
- generate dedicated layout entries for each topic dataset so tables can be positioned independently
- track dataset content in layout descriptors to control insight rendering and module availability
- rebuild the data table card to remove tab navigation, show the dataset name beneath the table, and improve empty-state messaging

## Testing
- pytest semanticnews/topics/tests.py *(fails: django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.)*

------
https://chatgpt.com/codex/tasks/task_b_68e35e45e8c4832894086270ccaf2b66