### PR TITLE
Add templates for paragraph and image widgets

### DIFF
--- a/semanticnews/topics/templates/widgets/image.html
+++ b/semanticnews/topics/templates/widgets/image.html
@@ -1,0 +1,25 @@
+{% load i18n %}
+{% with image_src=content.image_url|default:content.url %}
+<figure class="topic-widget-image text-center">
+    {% if image_src %}
+        <img
+            src="{{ image_src }}"
+            class="img-fluid rounded"
+            alt="{{ content.prompt|default:_('Generated illustration') }}"
+            loading="lazy"
+        />
+        {% if content.prompt %}
+            <figcaption class="figure-caption mt-2 text-muted">{{ content.prompt }}</figcaption>
+        {% endif %}
+    {% else %}
+        <div class="alert alert-info" role="status">
+            {% if content.prompt %}
+                <p class="mb-1">{% blocktrans %}Awaiting an image for:{% endblocktrans %}</p>
+                <p class="mb-0"><strong>{{ content.prompt }}</strong></p>
+            {% else %}
+                <p class="mb-0">{% trans "No image has been generated yet." %}</p>
+            {% endif %}
+        </div>
+    {% endif %}
+</figure>
+{% endwith %}

--- a/semanticnews/topics/templates/widgets/image_form.html
+++ b/semanticnews/topics/templates/widgets/image_form.html
@@ -1,0 +1,39 @@
+{% load i18n %}
+<div class="topic-widget-form" data-widget-form="image">
+    <div class="mb-3">
+        <label class="form-label" for="widget-image-prompt">{% trans "Image prompt" %}</label>
+        <textarea
+            id="widget-image-prompt"
+            class="form-control"
+            name="prompt"
+            rows="4"
+            placeholder="{% trans 'Describe the image you want to generate…' %}"
+        >{{ content.prompt|default_if_none:'' }}</textarea>
+        <div class="form-text text-muted">
+            {% blocktrans %}The prompt guides the image generation model and is visible in previews.{% endblocktrans %}
+        </div>
+    </div>
+    <div class="mb-3">
+        <label class="form-label" for="widget-image-url">{% trans "Image URL" %}</label>
+        <input
+            type="url"
+            id="widget-image-url"
+            class="form-control"
+            name="image_url"
+            value="{{ content.image_url|default_if_none:'' }}"
+            placeholder="https://"
+        />
+        <div class="form-text text-muted">
+            {% blocktrans %}Provide an existing image URL to use in previews or leave blank to generate a new image.{% endblocktrans %}
+        </div>
+    </div>
+    <div class="text-center" data-widget-image-preview>
+        {% with image_src=content.image_url %}
+            {% if image_src %}
+                <img src="{{ image_src }}" alt="" class="img-fluid rounded" />
+            {% else %}
+                <p class="text-muted mb-0">{% trans "No preview available yet." %}</p>
+            {% endif %}
+        {% endwith %}
+    </div>
+</div>

--- a/semanticnews/topics/templates/widgets/paragraph.html
+++ b/semanticnews/topics/templates/widgets/paragraph.html
@@ -1,0 +1,8 @@
+{% load i18n %}
+<div class="topic-widget-paragraph">
+    {% if content.text %}
+        <p class="mb-0">{{ content.text|default_if_none:''|linebreaksbr }}</p>
+    {% else %}
+        <p class="text-muted mb-0">{% trans "No content available." %}</p>
+    {% endif %}
+</div>

--- a/semanticnews/topics/templates/widgets/paragraph_form.html
+++ b/semanticnews/topics/templates/widgets/paragraph_form.html
@@ -1,0 +1,16 @@
+{% load i18n %}
+<div class="topic-widget-form" data-widget-form="paragraph">
+    <div class="mb-3">
+        <label class="form-label" for="widget-paragraph-text">{% trans "Paragraph" %}</label>
+        <textarea
+            id="widget-paragraph-text"
+            class="form-control"
+            name="text"
+            rows="6"
+            placeholder="{% trans 'Write your paragraph…' %}"
+        >{{ content.text|default_if_none:'' }}</textarea>
+        <div class="form-text text-muted">
+            {% blocktrans %}This text will appear in the published topic and in editor previews.{% endblocktrans %}
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add dedicated render templates for the paragraph and image widgets using their schema context
- provide widget form snippets that support editor previews and fallbacks when content is missing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690ef2f76670832885e1f67746da8d00)